### PR TITLE
Add system repository to provide database timestamps

### DIFF
--- a/src/main/java/fi/hsl/jore/importer/feature/system/repository/ISystemRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/system/repository/ISystemRepository.java
@@ -1,0 +1,13 @@
+package fi.hsl.jore.importer.feature.system.repository;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public interface ISystemRepository {
+    Instant currentTimestamp();
+
+    LocalDate currentDate();
+
+    LocalTime currentTime();
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/system/repository/SystemRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/system/repository/SystemRepository.java
@@ -1,0 +1,46 @@
+package fi.hsl.jore.importer.feature.system.repository;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Time;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Repository
+public class SystemRepository implements ISystemRepository {
+
+    private final DSLContext db;
+
+    @Autowired
+    public SystemRepository(final DSLContext db) {
+        this.db = db;
+    }
+
+    @Override
+    public Instant currentTimestamp() {
+        return db.select(DSL.currentInstant())
+                 .fetchOne()
+                 .value1();
+    }
+
+    @Override
+    public LocalDate currentDate() {
+        return db.select(DSL.currentLocalDate())
+                 .fetchOne()
+                 .value1();
+    }
+
+    @Override
+    public LocalTime currentTime() {
+        // Prefer LOCALTIME over CURRENT_TIME,
+        // See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_CURRENT_TIME
+        return db.select(DSL.field("LOCALTIME", Time.class))
+                 .fetchOne()
+                 .value1()
+                 .toLocalTime();
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/system/repository/package-info.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/system/repository/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package fi.hsl.jore.importer.feature.system.repository;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/src/test/java/fi/hsl/jore/importer/feature/common/dto/mixin/SystemTimeTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/common/dto/mixin/SystemTimeTest.java
@@ -6,6 +6,7 @@ import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.NodeType;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.PersistableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.repository.INodeRepository;
+import fi.hsl.jore.importer.feature.system.repository.ISystemRepository;
 import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,8 @@ public class SystemTimeTest extends IntegrationTest {
     // Let's use Nodes as an example entity with system time
     private final INodeRepository nodeRepository;
 
+    private final ISystemRepository systemRepository;
+
     private static final Point GEOM = GeometryUtil.toPoint(
             GeometryUtil.SRID_WGS84,
             new Coordinate(60.168988620, 24.949328727, 0)
@@ -38,19 +41,21 @@ public class SystemTimeTest extends IntegrationTest {
             new Coordinate(62.168988620, 26.949328727, 0)
     );
 
-    public SystemTimeTest(@Autowired final INodeRepository nodeRepository) {
+    public SystemTimeTest(@Autowired final INodeRepository nodeRepository,
+                          @Autowired final ISystemRepository systemRepository) {
         this.nodeRepository = nodeRepository;
+        this.systemRepository = systemRepository;
     }
 
     @Test
     public void testSystemTimeAfterInsert() {
-        final Instant before = Instant.now();
+        final Instant before = systemRepository.currentTimestamp();
 
         nodeRepository.upsert(List.of(
                 PersistableNode.of(ExternalId.of("a"), NodeType.CROSSROADS, GEOM)
         ));
 
-        final Instant after = Instant.now();
+        final Instant after = systemRepository.currentTimestamp();
 
         assertThat("Sanity check: upserting the entity was not instantaneous",
                    after.isAfter(before));
@@ -87,25 +92,25 @@ public class SystemTimeTest extends IntegrationTest {
 
     @Test
     public void testSystemTimeAfterUpdate() {
-        final Instant before = Instant.now();
+        final Instant before = systemRepository.currentTimestamp();
 
         nodeRepository.upsert(List.of(
                 PersistableNode.of(ExternalId.of("a"), NodeType.CROSSROADS, GEOM)
         ));
 
-        final Instant afterFirstInsert = Instant.now();
+        final Instant afterFirstInsert = systemRepository.currentTimestamp();
 
         nodeRepository.upsert(List.of(
                 PersistableNode.of(ExternalId.of("a"), NodeType.CROSSROADS, GEOM2)
         ));
 
-        final Instant afterSecondInsert = Instant.now();
+        final Instant afterSecondInsert = systemRepository.currentTimestamp();
 
         nodeRepository.upsert(List.of(
                 PersistableNode.of(ExternalId.of("a"), NodeType.CROSSROADS, GEOM3)
         ));
 
-        final Instant afterThirdInsert = Instant.now();
+        final Instant afterThirdInsert = systemRepository.currentTimestamp();
 
 
         final List<? extends IHasSystemTime> entities = nodeRepository.findAll();

--- a/src/test/java/fi/hsl/jore/importer/feature/system/repository/SystemRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/system/repository/SystemRepositoryTest.java
@@ -1,0 +1,41 @@
+package fi.hsl.jore.importer.feature.system.repository;
+
+import fi.hsl.jore.importer.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SystemRepositoryTest extends IntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SystemRepositoryTest.class);
+
+    private final ISystemRepository systemRepository;
+
+    public SystemRepositoryTest(@Autowired final ISystemRepository systemRepository) {
+        this.systemRepository = systemRepository;
+    }
+
+    @Test
+    public void testCurrentTimestamp() {
+        assertDoesNotThrow(() -> {
+            LOG.info("Current timestamp is {}", systemRepository.currentTimestamp());
+        });
+    }
+
+    @Test
+    public void testCurrentDate() {
+        assertDoesNotThrow(() -> {
+            LOG.info("Current date is {}", systemRepository.currentDate());
+        });
+    }
+
+    @Test
+    public void testCurrentTime() {
+        assertDoesNotThrow(() -> {
+            LOG.info("Current time is {}", systemRepository.currentTime());
+        });
+    }
+}


### PR DESCRIPTION
- Don't compare Java timestamps to database timestamps
  in tests, as on some systems the docker clock may
  drift significantly compared to the host clock

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/11)
<!-- Reviewable:end -->
