### PR TITLE
Use random geometries in tests

### DIFF
--- a/src/test/java/fi/hsl/jore/importer/TestGeometryUtil.java
+++ b/src/test/java/fi/hsl/jore/importer/TestGeometryUtil.java
@@ -1,0 +1,68 @@
+package fi.hsl.jore.importer;
+
+import com.google.common.base.Preconditions;
+import fi.hsl.jore.importer.util.GeometryUtil;
+import io.vavr.collection.List;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+public final class TestGeometryUtil {
+
+    private static final Random R = new Random();
+
+    private static final double TOLERANCE = 0.000001;
+
+    private TestGeometryUtil() {
+    }
+
+    private static double randomLatitude() {
+        return R.nextDouble() * 60.0;
+    }
+
+    private static double randomLongitude() {
+        return R.nextDouble() * 25.0;
+    }
+
+    private static Coordinate randomCoordinate() {
+        return new Coordinate(randomLatitude(), randomLongitude(), 0);
+    }
+
+    public static Point randomPoint() {
+        return GeometryUtil.toPoint(
+                GeometryUtil.SRID_WGS84,
+                randomCoordinate()
+        );
+    }
+
+    public static LineString randomLine(final int length) {
+        Preconditions.checkArgument(length >= 2, "LineString length must be at least 2");
+        final List<Coordinate> coords = IntStream.range(0, length)
+                                                 .boxed()
+                                                 .map(i -> randomCoordinate())
+                                                 .collect(List.collector());
+        return GeometryUtil.toLineString(GeometryUtil.SRID_WGS84,
+                                         coords);
+    }
+
+    public static LineString randomLine() {
+        return randomLine(2);
+    }
+
+    /**
+     * Plain assertThat(a, is(b)) sometimes rarely causes "expected 1.23, got 1.23" type issues
+     *
+     * @param a The first geometry
+     * @param b The second geometry
+     * @return True, if geometries match (wrt. a tolerance)
+     */
+    public static boolean geometriesMatch(final Geometry a,
+                                          final Geometry b) {
+        return a.getSRID() == b.getSRID() &&
+               a.equalsExact(b, TOLERANCE);
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ImportLinksStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ImportLinksStepTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -56,8 +57,9 @@ public class ImportLinksStepTest extends BatchIntegrationTest {
         final LineString expectedGeometry = GeometryUtil.toLineString(GeometryUtil.SRID_WGS84,
                                                                       List.of(nodeC,
                                                                               nodeD));
-        assertThat(link.geometry(),
-                   is(expectedGeometry));
+        assertThat(geometriesMatch(link.geometry(),
+                                   expectedGeometry),
+                   is(true));
         assertThat(link.networkType(),
                    is(NetworkType.ROAD));
         assertThat(link.points().isEmpty(),

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/link/support/LinkImportRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/link/support/LinkImportRepositoryTest.java
@@ -1,6 +1,7 @@
 package fi.hsl.jore.importer.feature.batch.link.support;
 
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.batch.util.RowStatus;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.infrastructure.link.dto.ImportableLink;
@@ -13,7 +14,6 @@ import fi.hsl.jore.importer.feature.infrastructure.node.dto.NodeType;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.PersistableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.generated.NodePK;
 import fi.hsl.jore.importer.feature.infrastructure.node.repository.INodeTestRepository;
-import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
@@ -21,47 +21,22 @@ import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class LinkImportRepositoryTest extends IntegrationTest {
 
-    private static final LineString LINE_1 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0),
-            new Coordinate(60.168896355, 24.945549266, 0)
-    );
-
-    private static final LineString LINE_2 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0),
-            new Coordinate(60.158896355, 24.935549266, 0)
-    );
-
-    private static final Point POINT_1 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point POINT_2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
-
-    private static final Point POINT_3 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.128988620, 24.239328727, 0)
-    );
-
-    private static final Point POINT_4 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.138988620, 24.339328727, 0)
-    );
+    private static final LineString LINE_1 = TestGeometryUtil.randomLine();
+    private static final LineString LINE_2 = TestGeometryUtil.randomLine();
+    private static final Point POINT_1 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_2 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_3 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_4 = TestGeometryUtil.randomPoint();
 
     private final ILinkImportRepository importRepository;
     private final ILinkTestRepository targetRepository;
@@ -168,8 +143,8 @@ public class LinkImportRepositoryTest extends IntegrationTest {
         final Link link = targetRepository.findById(existingId).orElseThrow();
 
         assertThat("The updated rows location was changed",
-                   link.geometry(),
-                   is(LINE_2));
+                   geometriesMatch(link.geometry(), LINE_2),
+                   is(true));
         assertThat(link.startNode(),
                    is(startNode));
         assertThat(link.endNode(),
@@ -216,8 +191,8 @@ public class LinkImportRepositoryTest extends IntegrationTest {
         final Link link = targetRepository.findById(existingId).orElseThrow();
 
         assertThat("The target row was not changed",
-                   link.geometry(),
-                   is(LINE_1));
+                   geometriesMatch(link.geometry(), LINE_1),
+                   is(true));
         assertThat(link.startNode(),
                    is(startNode));
         assertThat(link.endNode(),

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/node/support/NodeImportRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/node/support/NodeImportRepositoryTest.java
@@ -1,6 +1,7 @@
 package fi.hsl.jore.importer.feature.batch.node.support;
 
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.batch.util.RowStatus;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.ImportableNode;
@@ -9,7 +10,6 @@ import fi.hsl.jore.importer.feature.infrastructure.node.dto.NodeType;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.PersistableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.generated.NodePK;
 import fi.hsl.jore.importer.feature.infrastructure.node.repository.INodeTestRepository;
-import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
@@ -17,26 +17,19 @@ import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class NodeImportRepositoryTest extends IntegrationTest {
 
-    private static final Point POINT_1 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point POINT_2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
+    private static final Point POINT_1 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_2 = TestGeometryUtil.randomPoint();
 
     private final INodeImportRepository importRepository;
     private final INodeTestRepository targetRepository;
@@ -123,8 +116,8 @@ public class NodeImportRepositoryTest extends IntegrationTest {
         final Node node = targetRepository.findById(existingId).orElseThrow();
 
         assertThat("The updated rows location was changed",
-                   node.location(),
-                   is(POINT_2));
+                   geometriesMatch(node.location(), POINT_2),
+                   is(true));
     }
 
     @Test
@@ -158,8 +151,8 @@ public class NodeImportRepositoryTest extends IntegrationTest {
 
         final Node node = targetRepository.findById(existingId).orElseThrow();
         assertThat("The target row was not changed",
-                   node.location(),
-                   is(POINT_1));
+                   geometriesMatch(node.location(), POINT_1),
+                   is(true));
     }
 
     @Test

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/point/support/LinkPointImportRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/point/support/LinkPointImportRepositoryTest.java
@@ -1,6 +1,7 @@
 package fi.hsl.jore.importer.feature.batch.point.support;
 
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.batch.point.dto.LinkGeometry;
 import fi.hsl.jore.importer.feature.batch.util.RowStatus;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
@@ -14,68 +15,30 @@ import fi.hsl.jore.importer.feature.infrastructure.node.dto.NodeType;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.PersistableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.generated.NodePK;
 import fi.hsl.jore.importer.feature.infrastructure.node.repository.INodeTestRepository;
-import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class LinkPointImportRepositoryTest extends IntegrationTest {
 
-    private static final LineString LINE_1 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0),
-            new Coordinate(60.168896355, 24.945549266, 0)
-    );
-
-    private static final LineString LINEPOINTS_1 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0),
-            new Coordinate(60.168990620, 24.946028727, 0),
-            new Coordinate(60.168896355, 24.945549266, 0)
-    );
-
-    private static final LineString LINE_2 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0),
-            new Coordinate(60.158896355, 24.935549266, 0)
-    );
-
-    private static final LineString LINEPOINTS_2 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0),
-            new Coordinate(60.158908620, 24.937328727, 0),
-            new Coordinate(60.158896355, 24.935549266, 0)
-    );
-
-    private static final Point POINT_1 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point POINT_2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
-
-    private static final Point POINT_3 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point POINT_4 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
+    private static final LineString LINE_1 = TestGeometryUtil.randomLine();
+    private static final LineString LINEPOINTS_1 = TestGeometryUtil.randomLine(5);
+    private static final LineString LINE_2 = TestGeometryUtil.randomLine();
+    private static final LineString LINEPOINTS_2 = TestGeometryUtil.randomLine(5);
+    private static final Point POINT_1 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_2 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_3 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_4 = TestGeometryUtil.randomPoint();
 
     private final ILinkPointImportRepository importRepository;
     private final ILinkTestRepository targetRepository;
@@ -140,14 +103,14 @@ public class LinkPointImportRepositoryTest extends IntegrationTest {
         final Link link = targetRepository.findById(id).orElseThrow();
 
         assertThat("Target link should have the original geometry",
-                   link.geometry(),
-                   is(LINE_1));
+                   geometriesMatch(link.geometry(), LINE_1),
+                   is(true));
         assertThat("Target link should have line points",
                    link.points().isPresent(),
                    is(true));
         assertThat("Target link should have the correct line points",
-                   link.points().get(),
-                   is(LINEPOINTS_1));
+                   geometriesMatch(link.points().get(), LINEPOINTS_1),
+                   is(true));
     }
 
     @Test
@@ -202,13 +165,13 @@ public class LinkPointImportRepositoryTest extends IntegrationTest {
         final Link link = targetRepository.findById(id).orElseThrow();
 
         assertThat("Target link should have the original geometry",
-                   link.geometry(),
-                   is(LINE_1));
+                   geometriesMatch(link.geometry(), LINE_1),
+                   is(true));
         assertThat("Target link should have line points",
                    link.points().isPresent(),
                    is(true));
         assertThat("Target link should have the updated line points",
-                   link.points().get(),
-                   is(LINEPOINTS_2));
+                   geometriesMatch(link.points().get(), LINEPOINTS_2),
+                   is(true));
     }
 }

--- a/src/test/java/fi/hsl/jore/importer/feature/common/dto/mixin/SystemTimeTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/common/dto/mixin/SystemTimeTest.java
@@ -2,6 +2,7 @@ package fi.hsl.jore.importer.feature.common.dto.mixin;
 
 import com.google.common.collect.Range;
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.ImmutableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.Node;
@@ -10,10 +11,8 @@ import fi.hsl.jore.importer.feature.infrastructure.node.dto.PersistableNode;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.generated.NodePK;
 import fi.hsl.jore.importer.feature.infrastructure.node.repository.INodeTestRepository;
 import fi.hsl.jore.importer.feature.system.repository.ISystemRepository;
-import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,20 +28,9 @@ public class SystemTimeTest extends IntegrationTest {
 
     private final ISystemRepository systemRepository;
 
-    private static final Point GEOM = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point GEOM2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(61.168988620, 25.949328727, 0)
-    );
-
-    private static final Point GEOM3 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(62.168988620, 26.949328727, 0)
-    );
+    private static final Point GEOM = TestGeometryUtil.randomPoint();
+    private static final Point GEOM2 = TestGeometryUtil.randomPoint();
+    private static final Point GEOM3 = TestGeometryUtil.randomPoint();
 
     public SystemTimeTest(@Autowired final INodeTestRepository nodeRepository,
                           @Autowired final ISystemRepository systemRepository) {

--- a/src/test/java/fi/hsl/jore/importer/feature/infrastructure/link/repository/LinkRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/infrastructure/link/repository/LinkRepositoryTest.java
@@ -1,6 +1,7 @@
 package fi.hsl.jore.importer.feature.infrastructure.link.repository;
 
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.common.dto.mixin.IHasPK;
 import fi.hsl.jore.importer.feature.infrastructure.link.dto.Link;
@@ -15,11 +16,11 @@ import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -28,27 +29,10 @@ public class LinkRepositoryTest extends IntegrationTest {
     private final ILinkTestRepository linkRepository;
     private final INodeTestRepository nodeRepository;
 
-    private static final LineString GEOM = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0),
-            new Coordinate(60.168896355, 24.945549266, 0)
-    );
-
-    private static final LineString GEOM2 = GeometryUtil.toLineString(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0),
-            new Coordinate(60.158896355, 24.935549266, 0)
-    );
-
-    private static final Point POINT_1 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point POINT_2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
+    private static final LineString GEOM = TestGeometryUtil.randomLine();
+    private static final LineString GEOM2 = TestGeometryUtil.randomLine();
+    private static final Point POINT_1 = TestGeometryUtil.randomPoint();
+    private static final Point POINT_2 = TestGeometryUtil.randomPoint();
 
     public LinkRepositoryTest(@Autowired final ILinkTestRepository linkRepository,
                               @Autowired final INodeTestRepository nodeRepository) {
@@ -84,8 +68,8 @@ public class LinkRepositoryTest extends IntegrationTest {
 
         final Link linkFromDb = linkRepository.findById(linkId).orElseThrow();
 
-        assertThat(linkFromDb.geometry(),
-                   is(GEOM));
+        assertThat(geometriesMatch(linkFromDb.geometry(), GEOM),
+                   is(true));
         assertThat(linkFromDb.geometry().getSRID(),
                    is(GEOM.getSRID()));
         assertThat(linkFromDb.geometry().getSRID(),
@@ -124,9 +108,9 @@ public class LinkRepositoryTest extends IntegrationTest {
                        is(endNode));
         }
 
-        assertThat(linksFromDb.get(0).geometry(),
-                   is(GEOM));
-        assertThat(linksFromDb.get(1).geometry(),
-                   is(GEOM2));
+        assertThat(geometriesMatch(linksFromDb.get(0).geometry(), GEOM),
+                   is(true));
+        assertThat(geometriesMatch(linksFromDb.get(1).geometry(), GEOM2),
+                   is(true));
     }
 }

--- a/src/test/java/fi/hsl/jore/importer/feature/infrastructure/node/repository/NodeRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/infrastructure/node/repository/NodeRepositoryTest.java
@@ -1,6 +1,7 @@
 package fi.hsl.jore.importer.feature.infrastructure.node.repository;
 
 import fi.hsl.jore.importer.IntegrationTest;
+import fi.hsl.jore.importer.TestGeometryUtil;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.common.dto.mixin.IHasPK;
 import fi.hsl.jore.importer.feature.infrastructure.node.dto.ImmutableNode;
@@ -13,10 +14,10 @@ import io.vavr.collection.HashSet;
 import io.vavr.collection.List;
 import io.vavr.collection.Set;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -25,15 +26,8 @@ public class NodeRepositoryTest extends IntegrationTest {
 
     private final INodeTestRepository nodeRepository;
 
-    private static final Point GEOM = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.168988620, 24.949328727, 0)
-    );
-
-    private static final Point GEOM2 = GeometryUtil.toPoint(
-            GeometryUtil.SRID_WGS84,
-            new Coordinate(60.158988620, 24.939328727, 0)
-    );
+    private static final Point GEOM = TestGeometryUtil.randomPoint();
+    private static final Point GEOM2 = TestGeometryUtil.randomPoint();
 
     public NodeRepositoryTest(@Autowired final INodeTestRepository nodeRepository) {
         this.nodeRepository = nodeRepository;
@@ -51,10 +45,10 @@ public class NodeRepositoryTest extends IntegrationTest {
 
         final List<Node> nodesFromDb = nodeRepository.findAll();
 
-        assertThat(GEOM,
-                   is(nodesFromDb.get(0).location()));
-        assertThat(GEOM2,
-                   is(nodesFromDb.get(1).location()));
+        assertThat(geometriesMatch(nodesFromDb.get(0).location(), GEOM),
+                   is(true));
+        assertThat(geometriesMatch(nodesFromDb.get(1).location(), GEOM2),
+                   is(true));
         assertThat(GEOM.getSRID(),
                    is(GeometryUtil.SRID_WGS84));
         assertThat(GEOM.getSRID(),
@@ -83,8 +77,8 @@ public class NodeRepositoryTest extends IntegrationTest {
         final Node originalNode = nodesFromDb.get(0);
 
         assertThat("Node should have the initial geometry",
-                   GEOM,
-                   is(originalNode.location()));
+                   geometriesMatch(GEOM, originalNode.location()),
+                   is(true));
         assertThat("Insert and find() should return the same keys",
                    nodesFromDb.map(IHasPK::pk).toSet(),
                    is(HashSet.of(id)));
@@ -103,8 +97,8 @@ public class NodeRepositoryTest extends IntegrationTest {
         final Node updatedNode = nodesFromDb2.get(0);
 
         assertThat("Node geometry should have been updated",
-                   GEOM2,
-                   is(nodesFromDb2.get(0).location()));
+                   geometriesMatch(GEOM2, nodesFromDb2.get(0).location()),
+                   is(true));
         assertThat("Update and find() should return the same keys",
                    nodesFromDb2.map(IHasPK::pk).toSet(),
                    is(keys2));
@@ -144,8 +138,8 @@ public class NodeRepositoryTest extends IntegrationTest {
         final Node originalNode = nodesFromDb.get(0);
 
         assertThat("Node should have the initial geometry",
-                   GEOM,
-                   is(originalNode.location()));
+                   geometriesMatch(GEOM, originalNode.location()),
+                   is(true));
         assertThat("Insert and find() should return the same keys",
                    nodesFromDb.map(IHasPK::pk).toSet(),
                    is(HashSet.of(id)));


### PR DESCRIPTION
- Removes geometry construction noise from test setups
- One complication is that persisting geometries seems to
  sometimes lose accuracy, causing "expected 1.23, got 1.23"
  failures in tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/15)
<!-- Reviewable:end -->
