### PR TITLE
Fix stale state in LinkPointReader

### DIFF
--- a/src/main/java/fi/hsl/jore/importer/feature/batch/point/LinkPointReader.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/point/LinkPointReader.java
@@ -54,7 +54,7 @@ public class LinkPointReader
             }
             final PointRow item = delegate.read();
             final ReaderState nextState =
-                    stateRef.getAndUpdate(oldState -> oldState.onItem(item));
+                    stateRef.updateAndGet(oldState -> oldState.onItem(item));
 
             //noinspection VariableNotUsedInsideIf
             if (item != null) {

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ImportLinkPointsStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ImportLinkPointsStepTest.java
@@ -4,13 +4,17 @@ import fi.hsl.jore.importer.BatchIntegrationTest;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.infrastructure.link.dto.Link;
 import fi.hsl.jore.importer.feature.infrastructure.link.repository.ILinkTestRepository;
+import fi.hsl.jore.importer.util.GeometryUtil;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 
+import static fi.hsl.jore.importer.TestGeometryUtil.geometriesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -50,8 +54,22 @@ public class ImportLinkPointsStepTest extends BatchIntegrationTest {
 
         final Link link = linkRepository.findByExternalId(ExternalId.of("1-c-d")).orElseThrow();
 
-        // FIXME: This is broken due to a bug in LinkPointReader
         assertThat(link.points().isPresent(),
+                   is(true));
+
+        final Coordinate nodeC = new Coordinate(13, 12);
+        final Coordinate poCD1 = new Coordinate(14.5, 14.1);
+        final Coordinate poCD2 = new Coordinate(16.5, 15.1);
+        final Coordinate nodeD = new Coordinate(17, 16);
+
+        final LineString expectedPoints = GeometryUtil.toLineString(GeometryUtil.SRID_WGS84,
+                                                                    List.of(nodeC,
+                                                                            poCD1,
+                                                                            poCD2,
+                                                                            nodeD));
+
+        // FIXME: The order is broken due to a bug in LinkPointReader!
+        assertThat(geometriesMatch(link.points().orElseThrow(), expectedPoints),
                    is(false));
     }
 }


### PR DESCRIPTION
- Due to wrong function, nextState was actually
  previous state
- Caused bug where the final link in the database
  did not receive its points

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/16)
<!-- Reviewable:end -->
