### PR TITLE
Ensure that integration tests are run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
                 <configuration>
-                    <groups>integrationTest</groups>
                     <includes>
                         <include>**/*Test</include>
                         <include>**/*Tests</include>


### PR DESCRIPTION
The Maven Surefire plugin was configured to run all tests
which belong to the group integrationTest. However, because
the JUnit 5 test classes are not annotated with the
@Tag annotation, this configuration meant that no tests
were run. This commit fixes this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/28)
<!-- Reviewable:end -->
