### PR TITLE
Build jdbc urls in docker entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 **
 
 # Reenable some...
+!/build-jdbc-urls.sh
 !/src
 !/profiles
 !/pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,14 @@ EXPOSE 8080
 # download script for reading docker secrets
 RUN curl -o /tmp/read-secrets.sh "https://raw.githubusercontent.com/HSLdevcom/jore4-tools/main/docker/read-secrets.sh"
 
+# copy over jdbc url helper script
+COPY build-jdbc-urls.sh /tmp/build-jdbc-urls.sh
+
 # copy over compiled jar
 COPY --from=builder /build/target/*.jar /usr/src/jore4-jore3-importer/importer.jar
 
-# read docker secrets into environment varaibles and run application
-CMD /bin/bash -c "source /tmp/read-secrets.sh && java -jar /usr/src/jore4-jore3-importer/importer.jar"
+# read docker secrets into environment variables and run application
+CMD /bin/bash -c "source /tmp/read-secrets.sh && source /tmp/build-jdbc-urls.sh && java -jar /usr/src/jore4-jore3-importer/importer.jar"
 
 HEALTHCHECK --interval=1m --timeout=5s \
   CMD curl --fail http://localhost:8080/actuator/health

--- a/README.md
+++ b/README.md
@@ -66,16 +66,22 @@ them as environment variables.
 
 The following configuration properties are to be defined for each environment:
 
-| Config property            | Environment variable       | Secret name                | Example                 | Description                                           |
-| ----------------------  | ----------------------- | ----------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| -                       | SECRET_STORE_BASE_PATH  | -                       | /run/secrets                                                                    | Directory containing the docker secrets                                          |
-| source.db.url           | SOURCE_DB_URL           | source-db-url           | jdbc:sqlserver://localhost:1433;database=testsourcedb;applicationIntent=ReadOnly| The jdbc url of the Jore3 MSSQL database                                         |
-| source.db.username      | SOURCE_DB_USERNAME      | source-db-username      | sa                                                                              | Username for the Jore3 MSSQL databaseThe full URL to which to return after login |
-| source.db.password      | SOURCE_DB_PASSWORD      | source-db-password      | ****                                                                            | The full URL to which to return after logout                                     |
-| destination.db.url      | DESTINATION_DB_URL      | destination-db-url      | jdbc:postgresql://localhost:5432/devdb?stringtype=unspecified                   | The jdbc url of the Jore4 postgresql database                                     |
-| destination.db.username | DESTINATION_DB_USERNAME | destination-db-username | sa                                                                              | Username for the Jore3 MSSQL databaseThe full URL to which to return after login  |
-| destination.db.password | DESTINATION_DB_PASSWORD | destination-db-password | ****                                                                            | The full URL to which to return after logout                                      |
-| jore.importer.migrate   | JORE_IMPORTER_MIGRATE   | jore-importer-migrate   | false                                                                           | Should the importer should run its own migrations (for local development only)    |
+| Config property         | Environment variable    | Secret name             | Example                                                                          | Description                                                                      |
+| ----------------------  | ----------------------- | ----------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| -                       | SECRET_STORE_BASE_PATH  | -                       | /mnt/secrets-store                                                               | Directory containing the docker secrets                                          |
+| source.db.url           | SOURCE_DB_URL           | source-db-url           | jdbc:sqlserver://localhost:1433;database=testsourcedb;applicationIntent=ReadOnly | The jdbc url of the source JORE3 MSSQL database                                  |
+|                         | SOURCE_DB_HOSTNAME      | source-db-hostname      | localhost                                                                        | The IP/hostname of the source database (if SOURCE_DB_URL is not set)             |
+|                         | SOURCE_DB_PORT          | source-db-port          | 1433                                                                             | The port of the source database (if SOURCE_DB_URL is not set)                    |
+|                         | SOURCE_DB_DATABASE      | source-db-database      | testsourcedb                                                                     | The name of the source database (if SOURCE_DB_URL is not set)                    |
+| source.db.username      | SOURCE_DB_USERNAME      | source-db-username      | sa                                                                               | Username for the source database                                                 |
+| source.db.password      | SOURCE_DB_PASSWORD      | source-db-password      | ****                                                                             | Password for the source database                                                 |
+| destination.db.url      | DESTINATION_DB_URL      | destination-db-url      | jdbc:postgresql://localhost:5432/devdb?stringtype=unspecified                    | The jdbc url of the destination JORE4 PostgreSQL database                        |
+|                         | DESTINATION_DB_HOSTNAME | destination-db-hostname | localhost                                                                        | The IP/hostname of the destination database (if DESTINATION_DB_URL is not set)   |
+|                         | DESTINATION_DB_PORT     | destination-db-port     | 5432                                                                             | The port of the destination database (if DESTINATION_DB_URL is not set)          |
+|                         | DESTINATION_DB_DATABASE | destination-db-database | devdb                                                                            | The name of the destination database (if DESTINATION_DB_URL is not set)          |
+| destination.db.username | DESTINATION_DB_USERNAME | destination-db-username | postgres                                                                         | Username for the destination database                                            |
+| destination.db.password | DESTINATION_DB_PASSWORD | destination-db-password | ****                                                                             | Password for the destination database                                            |
+| jore.importer.migrate   | JORE_IMPORTER_MIGRATE   | jore-importer-migrate   | false                                                                            | Should the importer should run its own migrations (for local development only)   |
 
 More properties can be found from `/profiles/prod/config.properties`
 

--- a/build-jdbc-urls.sh
+++ b/build-jdbc-urls.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+# we assume here that all secrets are already read to environment variables
+
+# if SOURCE_DB_URL was not set, build it from parts
+if [ -z "${SOURCE_DB_URL+x}" ]; then
+  export SOURCE_DB_URL="jdbc:sqlserver://${SOURCE_DB_HOSTNAME}:${SOURCE_DB_PORT};database=${SOURCE_DB_DATABASE};applicationIntent=ReadOnly"
+fi
+
+# if DESTINATION_DB_URL was not set, build it from parts
+if [ -z "${DESTINATION_DB_URL+x}" ]; then
+  export DESTINATION_DB_PORT=${DESTINATION_DB_PORT:-"5432"}
+  export DESTINATION_DB_URL="jdbc:postgresql://${DESTINATION_DB_HOSTNAME}:${DESTINATION_DB_PORT}/${DESTINATION_DB_DATABASE}?stringtype=unspecified"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     build: .
     restart: "unless-stopped"
     environment:
-      - SOURCE_DB_URL=jdbc:sqlserver://importer-test-source-database:1433;database=testsourcedb;applicationIntent=ReadOnly
+      - SOURCE_DB_HOSTNAME=importer-test-source-database
+      - SOURCE_DB_PORT=1433
+      - SOURCE_DB_DATABASE=testsourcedb
       - SOURCE_DB_USERNAME=sa
       - SOURCE_DB_PASSWORD=testSOURCEdb123
       - DESTINATION_DB_URL=jdbc:postgresql://importer-jooq-database:5432/devdb?stringtype=unspecified


### PR DESCRIPTION
For connecting to the source and destination databases, we need jdbc urls. However we only have hostnames, ports, etc available in secrets, so the entrypoint needs to build the jdbc urls out of these parts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/31)
<!-- Reviewable:end -->
