### PR TITLE
Improve route import tests

### DIFF
--- a/src/test/java/fi/hsl/jore/importer/feature/batch/route/support/RouteImportRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/route/support/RouteImportRepositoryTest.java
@@ -110,6 +110,15 @@ class RouteImportRepositoryTest {
         @ExtendWith(SoftAssertionsExtension.class)
         class WhenStagingTableHasRows {
 
+            private final UUID EXPECTED_NETWORK_LINE_ID = UUID.fromString("579db108-1f52-4364-9815-5f17c84ce3fb");
+            private final String EXPECTED_NETWORK_ROUTE_EXT_ID = "1001";
+            private final String EXPECTED_NETWORK_ROUTE_NUMBER = "1";
+            private final String EXPECTED_FINNISH_ROUTE_NAME = "Keskustori - Etelä-Hervanta";
+            private final String EXPECTED_SWEDISH_ROUTE_NAME = "Central torget - Södra Hervanta";
+
+            private final String LOCALE_FI_FI = "fi_FI";
+            private final String LOCALE_SV_SE = "sv_SE";
+
             @Nested
             @DisplayName("When the target table is empty")
             @Sql(scripts = {
@@ -160,6 +169,59 @@ class RouteImportRepositoryTest {
                             )
                             .containsOnly(id);
                 }
+
+                @Test
+                @DisplayName("Should insert the imported row into the target table")
+                void shouldInsertImportedRowIntoTargetTable(SoftAssertions softAssertions) {
+                    final Map<RowStatus, Set<RoutePK>> result = importRepository.commitStagingToTarget();
+                    final RoutePK id = result.get(RowStatus.INSERTED).get().get();
+
+                    final Route inserted = targetRepository.findById(id).get();
+
+                    softAssertions.assertThat(inserted.line().value())
+                            .overridingErrorMessage(
+                                    "Expected the network line id to be: %s but was: %s",
+                                    EXPECTED_NETWORK_LINE_ID,
+                                    inserted.line().value()
+                            )
+                            .isEqualTo(EXPECTED_NETWORK_LINE_ID);
+
+                    softAssertions.assertThat(inserted.externalId().value())
+                            .overridingErrorMessage(
+                                    "Expected the network route ext id to be: %s but was: %s",
+                                    EXPECTED_NETWORK_ROUTE_EXT_ID,
+                                    inserted.externalId().value()
+                            )
+                            .isEqualTo(EXPECTED_NETWORK_ROUTE_EXT_ID);
+
+                    softAssertions.assertThat(inserted.routeNumber())
+                            .overridingErrorMessage(
+                                    "Expected the route number to be: %s but was: %s",
+                                    EXPECTED_NETWORK_ROUTE_NUMBER,
+                                    inserted.routeNumber()
+                            )
+                            .isEqualTo(EXPECTED_NETWORK_ROUTE_NUMBER);
+
+                    final MultilingualString routeName = inserted.name();
+
+                    final String finnishRouteName = routeName.values().get(LOCALE_FI_FI).get();
+                    softAssertions.assertThat(finnishRouteName)
+                            .overridingErrorMessage(
+                                    "Expected that the updated Finnish route name to be: %s but was: %s",
+                                    EXPECTED_FINNISH_ROUTE_NAME,
+                                    finnishRouteName
+                            )
+                            .isEqualTo(EXPECTED_FINNISH_ROUTE_NAME);
+
+                    final String swedishRouteName = routeName.values().get(LOCALE_SV_SE).get();
+                    softAssertions.assertThat(swedishRouteName)
+                            .overridingErrorMessage(
+                                    "Expected that the updated Swedish route name to be: %s but was: %s",
+                                    EXPECTED_SWEDISH_ROUTE_NAME,
+                                    swedishRouteName
+                            )
+                            .isEqualTo(EXPECTED_SWEDISH_ROUTE_NAME);
+                }
             }
 
             @Nested
@@ -174,14 +236,6 @@ class RouteImportRepositoryTest {
             class WhenTargetTableContainsImportedRoute {
 
                 private final UUID EXPECTED_NETWORK_ROUTE_ID = UUID.fromString("484d89ae-f365-4c9b-bb1a-8f7b783e95f3");
-                private final UUID EXPECTED_NETWORK_LINE_ID = UUID.fromString("579db108-1f52-4364-9815-5f17c84ce3fb");
-                private final String EXPECTED_NETWORK_ROUTE_EXT_ID = "1001";
-                private final String EXPECTED_NETWORK_ROUTE_NUMBER = "1";
-                private final String EXPECTED_FINNISH_ROUTE_NAME = "Keskustori - Etelä-Hervanta";
-                private final String EXPECTED_SWEDISH_ROUTE_NAME = "Central torget - Södra Hervanta";
-
-                private final String LOCALE_FI_FI = "fi_FI";
-                private final String LOCALE_SV_SE = "sv_SE";
 
                 @Test
                 @DisplayName("Should update the information of the existing row")
@@ -205,18 +259,8 @@ class RouteImportRepositoryTest {
                 @Test
                 @DisplayName("Should update only the route name of the existing route")
                 void shouldUpdateOnlyRouteNameOfExistingRoute(SoftAssertions softAssertions) {
-                    final Map<RowStatus, Set<RoutePK>> result = importRepository.commitStagingToTarget();
-
-                    final RoutePK id = result.get(RowStatus.UPDATED).get().get();
-                    final Route updated = targetRepository.findById(id).get();
-
-                    softAssertions.assertThat(updated.pk().value())
-                            .overridingErrorMessage(
-                                    "Expected the network route id to be: %s but was: %s",
-                                    EXPECTED_NETWORK_ROUTE_ID,
-                                    updated.pk().value()
-                            )
-                            .isEqualTo(EXPECTED_NETWORK_ROUTE_ID);
+                    importRepository.commitStagingToTarget();
+                    final Route updated = targetRepository.findById(RoutePK.of(EXPECTED_NETWORK_ROUTE_ID)).get();
 
                     softAssertions.assertThat(updated.line().value())
                             .overridingErrorMessage(


### PR DESCRIPTION
- Add test cases which ensures that the imported
  route is inserted into the target table.
- Remove the unnecessary id assertion done in the
  shouldUpdateOnlyRouteNameOfExistingRoute() method.
  This assertion is not needed because if the updated
  route is found from the database, it has the correct id.