### PR TITLE
Read scheduled stop points for transmodel import

### DIFF
--- a/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
+++ b/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
@@ -36,8 +36,8 @@ import fi.hsl.jore.importer.feature.batch.route_link.dto.RouteLinksAndAttributes
 import fi.hsl.jore.importer.feature.batch.route_link.support.IRouteLinkImportRepository;
 import fi.hsl.jore.importer.feature.batch.route_link.support.IRoutePointImportRepository;
 import fi.hsl.jore.importer.feature.batch.route_link.support.IRouteStopPointImportRepository;
-import fi.hsl.jore.importer.feature.batch.scheduled_stop_point.ScheduledStopPointProcessor;
-import fi.hsl.jore.importer.feature.batch.scheduled_stop_point.ScheduledStopPointReader;
+import fi.hsl.jore.importer.feature.batch.scheduled_stop_point.ScheduledStopPointImportProcessor;
+import fi.hsl.jore.importer.feature.batch.scheduled_stop_point.ScheduledStopPointImportReader;
 import fi.hsl.jore.importer.feature.batch.scheduled_stop_point.support.IScheduledStopPointImportRepository;
 import fi.hsl.jore.importer.feature.infrastructure.link.dto.ImportableLink;
 import fi.hsl.jore.importer.feature.infrastructure.link_shape.dto.ImportableLinkShape;
@@ -486,13 +486,13 @@ public class JobConfig extends BatchConfig {
     }
 
     @Bean
-    public Step importScheduledStopPointsStep(final ScheduledStopPointReader reader,
+    public Step importScheduledStopPointsStep(final ScheduledStopPointImportReader reader,
                                               final IScheduledStopPointImportRepository repository) {
         return steps.get("importScheduledStopPointsStep")
                 .allowStartIfComplete(true)
                 .<JrScheduledStopPoint, ImportableScheduledStopPoint>chunk(1000)
                 .reader(reader.build())
-                .processor(new ScheduledStopPointProcessor())
+                .processor(new ScheduledStopPointImportProcessor())
                 .writer(new GenericImportWriter<>(repository))
                 .build();
     }

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportMapper.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportMapper.java
@@ -1,0 +1,64 @@
+package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.hsl.jore.importer.config.jooq.converter.geometry.GeometryConverter;
+import fi.hsl.jore.importer.feature.common.converter.IJsonbConverter;
+import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
+import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
+import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.annotation.Nullable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Objects;
+
+import static fi.hsl.jore.importer.feature.batch.util.JdbcUtil.getOptionalString;
+
+/**
+ * Maps a result set row into an {@link ExportableScheduledStopPoint} object.
+ */
+public class ScheduledStopPointExportMapper implements RowMapper<ExportableScheduledStopPoint> {
+
+    public static final String SQL_PATH = "classpath:export/export_scheduled_stop_points.sql";
+    private static final GeometryConverter POINT_CONVERTER = new GeometryConverter(Geometry.TYPENAME_POINT);
+
+    private final ObjectMapper objectMapper;
+
+    public ScheduledStopPointExportMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public ExportableScheduledStopPoint mapRow(ResultSet resultSet,
+                                               int rowNumber) throws SQLException {
+        return ExportableScheduledStopPoint.of(
+                ExternalId.of(resultSet.getString("external_id")),
+                getOptionalString(resultSet, "ely_number"),
+                pointFromDatabaseObject(resultSet.getObject("location")),
+                nameFromJsonString(resultSet.getString("name"))
+        );
+    }
+
+    private Point pointFromDatabaseObject(@Nullable Object databaseObject) throws SQLException {
+        if (databaseObject == null) {
+            throw new SQLException("Cannot parse location because the result set contained null value");
+        }
+
+        return (Point) Objects.requireNonNull(POINT_CONVERTER.from(databaseObject));
+    }
+
+    private MultilingualString nameFromJsonString(String nameAsJson) throws SQLException {
+        try {
+            HashMap<String, String> names = objectMapper.readValue(nameAsJson, HashMap.class);
+            return MultilingualString.of(names);
+        }
+        catch (JsonProcessingException e) {
+            throw new SQLException("Could not parse multilingual name from result set because of an error", e);
+        }
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportReader.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportReader.java
@@ -1,0 +1,49 @@
+package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.hsl.jore.importer.feature.batch.util.ResourceUtil;
+import fi.hsl.jore.importer.feature.common.converter.IJsonbConverter;
+import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+
+/**
+ * Reads the imported scheduled stop points from the import
+ * schemas which are found from the database of this Spring
+ * Boot application.
+ */
+@Component
+public class ScheduledStopPointExportReader {
+
+    private static final String NAME = "stopPointExportReader";
+
+    private final DataSource dataSource;
+    private final ObjectMapper objectMapper;
+    private final String sql;
+
+    @Autowired
+    public ScheduledStopPointExportReader(@Qualifier("destinationDataSource") final DataSource dataSource,
+                                          final ObjectMapper objectMapper,
+                                          @Value(ScheduledStopPointExportMapper.SQL_PATH) final Resource sqlResource) {
+        this.dataSource = dataSource;
+        this.objectMapper = objectMapper;
+        this.sql = ResourceUtil.fromResource(sqlResource);
+    }
+
+    public JdbcCursorItemReader<ExportableScheduledStopPoint> build() {
+        // The default fetch size seems to be 128 items
+        return new JdbcCursorItemReaderBuilder<ExportableScheduledStopPoint>()
+                .dataSource(dataSource)
+                .name(NAME)
+                .sql(sql)
+                .rowMapper(new ScheduledStopPointExportMapper(objectMapper))
+                .build();
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportMapper.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportMapper.java
@@ -14,7 +14,7 @@ import static fi.hsl.jore.importer.feature.batch.util.JdbcUtil.getStringOrThrow;
 /**
  * Maps rows read from the source database to {@link JrScheduledStopPoint} objects.
  */
-public class ScheduledStopPointMapper implements RowMapper<JrScheduledStopPoint> {
+public class ScheduledStopPointImportMapper implements RowMapper<JrScheduledStopPoint> {
 
     public static final String SQL_PATH = "classpath:import/import_scheduled_stop_points.sql";
 

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportProcessor.java
@@ -11,7 +11,7 @@ import org.springframework.batch.item.ItemProcessor;
  * Transforms the input data read from the source database into
  * a format which can be inserted into the target database.
  */
-public class ScheduledStopPointProcessor implements ItemProcessor<JrScheduledStopPoint, ImportableScheduledStopPoint> {
+public class ScheduledStopPointImportProcessor implements ItemProcessor<JrScheduledStopPoint, ImportableScheduledStopPoint> {
 
     @Override
     public ImportableScheduledStopPoint process(JrScheduledStopPoint input) throws Exception {

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportReader.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointImportReader.java
@@ -16,7 +16,7 @@ import javax.sql.DataSource;
  * Reads the imported scheduled stop points from the source database.
  */
 @Component
-public class ScheduledStopPointReader {
+public class ScheduledStopPointImportReader {
 
     private static final String NAME = "stopPointReader";
 
@@ -24,8 +24,8 @@ public class ScheduledStopPointReader {
     private final String sql;
 
     @Autowired
-    public ScheduledStopPointReader(@Qualifier("sourceDataSource") final DataSource sourceDataSource,
-                                    @Value(ScheduledStopPointMapper.SQL_PATH) final Resource sqlResource) {
+    public ScheduledStopPointImportReader(@Qualifier("sourceDataSource") final DataSource sourceDataSource,
+                                          @Value(ScheduledStopPointImportMapper.SQL_PATH) final Resource sqlResource) {
         this.sourceDataSource = sourceDataSource;
         this.sql = ResourceUtil.fromResource(sqlResource);
     }
@@ -36,7 +36,7 @@ public class ScheduledStopPointReader {
                 .dataSource(sourceDataSource)
                 .name(NAME)
                 .sql(sql)
-                .rowMapper(new ScheduledStopPointMapper())
+                .rowMapper(new ScheduledStopPointImportMapper())
                 .build();
     }
 }

--- a/src/main/java/fi/hsl/jore/importer/feature/network/scheduled_stop_point/dto/ExportableScheduledStopPoint.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/network/scheduled_stop_point/dto/ExportableScheduledStopPoint.java
@@ -1,0 +1,31 @@
+package fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto;
+
+import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
+import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
+import org.immutables.value.Value;
+import org.locationtech.jts.geom.Point;
+
+import java.util.Optional;
+
+/**
+ * Contains the information of a scheduled stop point which is
+ * required when we want to export scheduled stop points to the
+ * Jore 4 transmodel schema.
+ */
+@Value.Immutable
+public interface ExportableScheduledStopPoint extends CommonFields<ExportableScheduledStopPoint> {
+
+    Point location();
+
+    static ImmutableExportableScheduledStopPoint of(final ExternalId externalId,
+                                                    final Optional<String> elynumber,
+                                                    final Point location,
+                                                    final MultilingualString name) {
+        return ImmutableExportableScheduledStopPoint.builder()
+                .externalId(externalId)
+                .elyNumber(elynumber)
+                .location(location)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/resources/export/export_scheduled_stop_points.sql
+++ b/src/main/resources/export/export_scheduled_stop_points.sql
@@ -1,0 +1,7 @@
+SELECT s.scheduled_stop_point_ext_id AS external_id,
+       s.scheduled_stop_point_ely_number AS ely_number,
+       n.infrastructure_node_location AS location,
+       s.scheduled_stop_point_name AS name
+FROM network.scheduled_stop_points s
+         JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = s.infrastructure_node_id)
+WHERE s.scheduled_stop_point_ely_number IS NOT NULL

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportReaderTest.java
@@ -1,0 +1,120 @@
+package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
+
+import fi.hsl.jore.importer.IntTest;
+import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@IntTest
+class ScheduledStopPointExportReaderTest {
+
+    private final JdbcCursorItemReader<ExportableScheduledStopPoint> reader;
+
+    @Autowired
+    ScheduledStopPointExportReaderTest(ScheduledStopPointExportReader reader) {
+        this.reader = reader.build();
+    }
+
+    @BeforeEach
+    void openReader() {
+        this.reader.open(new ExecutionContext());
+    }
+
+    @AfterEach
+    void closeReader() {
+        this.reader.close();
+    }
+
+    @Nested
+    @DisplayName("When the source table is empty")
+    @Sql(scripts = "/sql/destination/drop_tables.sql")
+    class WhenSourceTableIsEmpty {
+
+        @Test
+        @DisplayName("The first invocation of the read() method must return null")
+        void firstInvocationOfReadMethodMustReturnNull() throws Exception {
+            ExportableScheduledStopPoint found = reader.read();
+            assertThat(found).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("When the source table has one scheduled stop point")
+    @Sql(scripts = {
+            "/sql/destination/drop_tables.sql",
+            "/sql/destination/populate_infrastructure_nodes.sql",
+            "/sql/destination/populate_scheduled_stop_points.sql",
+            "/sql/destination/populate_scheduled_stop_points_staging.sql"
+    })
+    @ExtendWith(SoftAssertionsExtension.class)
+    class WhenSourceTableHasOneScheduledStopPoint {
+
+        private static final String EXPECTED_ELY_NUMBER = "1234567891";
+        private static final String EXPECTED_EXTERNAL_ID = "c";
+        private static final double EXPECTED_X_COORDINATE = 6;
+        private static final double EXPECTED_Y_COORDINATE = 5;
+        private static final String EXPECTED_FINNISH_NAME = "Yliopisto vanha";
+        private static final String EXPECTED_SWEDISH_NAME = "Universitetet gamla";
+
+        private static final String LOCALE_FINNISH = "fi_FI";
+        private static final String LOCALE_SWEDISH = "sv_SE";
+
+        @Test
+        @DisplayName("The first invocation of the read() method must return the found scheduled stop point")
+        void firstInvocationOfReadMethodMustReturnFoundScheduledStopPoint(SoftAssertions softAssertions) throws Exception {
+            ExportableScheduledStopPoint found = reader.read();
+
+            softAssertions.assertThat(found.externalId().value())
+                    .as("externalId")
+                    .isEqualTo(EXPECTED_EXTERNAL_ID);
+
+            softAssertions.assertThat(found.elyNumber().get())
+                    .as("elyNumber")
+                    .isEqualTo(EXPECTED_ELY_NUMBER);
+
+            double XCoordinate = found.location().getX();
+            assertThat(XCoordinate)
+                    .as("X coordinate")
+                    .isEqualTo(EXPECTED_X_COORDINATE);
+
+            double YCoordinate = found.location().getY();
+            assertThat(YCoordinate)
+                    .as("Y coordinate")
+                    .isEqualTo(EXPECTED_Y_COORDINATE);
+
+            String finnishName = found.name().values().getOrElse(LOCALE_FINNISH, "null");
+            assertThat(finnishName)
+                    .as("finnishName")
+                    .isEqualTo(EXPECTED_FINNISH_NAME);
+
+            String swedishName = found.name().values().getOrElse(LOCALE_SWEDISH, "null");
+            assertThat(swedishName)
+                    .as("swedishName")
+                    .isEqualTo(EXPECTED_SWEDISH_NAME);
+        }
+
+        @Test
+        @DisplayName("The second invocation of the read() method must return null")
+        void secondInvocationOfReadMethodMustReturnNull() throws Exception {
+            //The first invocation returns the scheduled stop found from the database.
+            ExportableScheduledStopPoint first = reader.read();
+            assertThat(first).isNotNull();
+
+            //Because there are no more scheduled stop points, this invocation must return null.
+            ExportableScheduledStopPoint second = reader.read();
+            assertThat(second).isNull();
+        }
+    }
+}


### PR DESCRIPTION
- Rename Spring Batch components which import scheduled stop
  points from Jore 3 database.
- Implement a Spring Batch item reader which can read the scheduled
  stop points from the network.scheduled_stop_points and
  infrastructure_network.infrastructure_nodes tables.
- Write tests for item reader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/41)
<!-- Reviewable:end -->
