### PR TITLE
Process scheduled stop points for transmodel import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <vavr.version>0.10.3</vavr.version>
         <immutables.version>2.8.2</immutables.version>
         <geotools.version>25-RC</geotools.version>
+        <geojson-jackson.version>1.14</geojson-jackson.version>
         <postgresql.version>42.2.19</postgresql.version>
 
         <!-- Test library version -->
@@ -152,6 +153,12 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-wkt</artifactId>
             <version>${geotools.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>de.grundid.opendatalab</groupId>
+            <artifactId>geojson-jackson</artifactId>
+            <version>${geojson-jackson.version}</version>
         </dependency>
 
         <!-- Flyway migrations are only run through Java during local development! -->

--- a/profiles/ci/config.properties
+++ b/profiles/ci/config.properties
@@ -41,3 +41,5 @@ test.destination.db.min.connections=0
 test.destination.db.max.connections=5
 test.destination.db.username=testdestinationdb
 test.destination.db.password=testdestinationdb
+
+digiroad.stop.csv.file.path=

--- a/profiles/dev/config.properties
+++ b/profiles/dev/config.properties
@@ -41,3 +41,5 @@ test.destination.db.min.connections=0
 test.destination.db.max.connections=5
 test.destination.db.username=testdestinationdb
 test.destination.db.password=testdestinationdb
+
+digiroad.stop.csv.file.path=

--- a/profiles/prod/config.properties
+++ b/profiles/prod/config.properties
@@ -23,3 +23,5 @@ init.db.username=testdestinationdb
 init.db.password=testdestinationdb
 jooq.generator.db.dialect=org.jooq.meta.postgres.PostgresDatabase
 jooq.sql.dialect=POSTGRES
+
+digiroad.stop.csv.file.path=

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportMapper.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportMapper.java
@@ -3,7 +3,6 @@ package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.hsl.jore.importer.config.jooq.converter.geometry.GeometryConverter;
-import fi.hsl.jore.importer.feature.common.converter.IJsonbConverter;
 import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
 import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
@@ -1,0 +1,84 @@
+package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
+
+import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStopDirection;
+import fi.hsl.jore.importer.feature.digiroad.service.DigiroadStopService;
+import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
+import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Combines the stop information imported from Jore 3 and Digiroad, and creates
+ * a new {@link TransmodelScheduledStopPoint} object which can be inserted into
+ * the Jore 4 database.
+ */
+public class ScheduledStopPointExportProcessor implements ItemProcessor<ExportableScheduledStopPoint, TransmodelScheduledStopPoint> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledStopPointExportProcessor.class);
+
+    private static final String LANGUAGE_CODE_FINNISH = "fi_FI";
+
+    private final DigiroadStopService digiroadStopService;
+
+    @Autowired
+    public ScheduledStopPointExportProcessor(DigiroadStopService digiroadStopService) {
+        this.digiroadStopService = digiroadStopService;
+    }
+
+    @Override
+    public TransmodelScheduledStopPoint process(ExportableScheduledStopPoint jore3Stop) throws Exception {
+        LOGGER.debug("Processing Jore 3 stop: {}", jore3Stop);
+
+        //At the moment we export stops which don't have an ely number.
+        //Thus, we must return null if the stop has no ely number
+        //because this ensures that the stop isn't processed any further.
+        if (jore3Stop.elyNumber().isEmpty()) {
+            LOGGER.error("Jore 3 stop with id: {} isn't processed any further because it has no ely number",
+                    jore3Stop.externalId().value()
+            );
+            return null;
+        }
+
+        String elyNumber = jore3Stop.elyNumber().get();
+        Optional<DigiroadStop> digiroadStopContainer = digiroadStopService.findByElyNumber(elyNumber);
+
+        //If we cannot find the corresponding Digiroad stop, we cannot
+        //determine the coordinates of the stop. Thus, we must return null
+        //because this ensures that the stop isn't processed any further.
+        if (digiroadStopContainer.isEmpty()) {
+            LOGGER.error("Jore 3 stop with id: {} isn't processed any further no digiroad stop was found with ely number: {}",
+                    jore3Stop.externalId().value(),
+                    elyNumber
+            );
+            return null;
+        }
+
+        DigiroadStop digiroadStop = digiroadStopContainer.get();
+        LOGGER.debug("Found Digiroad stop: {}", digiroadStop);
+
+        TransmodelScheduledStopPoint transmodelStop = TransmodelScheduledStopPoint.of(
+                jore3Stop.externalId().value(),
+                digiroadStop.externalLinkId(),
+                isDirectionForwardOnInfraLink(digiroadStop.directionOnInfraLink()),
+                constructLabel(jore3Stop.name()),
+                jore3Stop.location()
+        );
+
+        LOGGER.debug("Created scheduled stop point: {}", transmodelStop);
+        return transmodelStop;
+    }
+
+    private boolean isDirectionForwardOnInfraLink(DigiroadStopDirection stopDirection) {
+        return stopDirection == DigiroadStopDirection.FORWARD;
+    }
+
+    private String constructLabel(MultilingualString name) {
+        return name.values().get(LANGUAGE_CODE_FINNISH).get();
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStop.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStop.java
@@ -14,11 +14,11 @@ public interface DigiroadStop {
 
     DigiroadStopDirection directionOnInfraLink();
 
-    String externalStopId();
+    String digiroadStopId();
 
-    String externalLinkId();
+    String digiroadLinkId();
 
-    String elyNumber();
+    int nationalId();
 
     Point location();
 
@@ -26,18 +26,18 @@ public interface DigiroadStop {
 
     Optional<String> nameSwedish();
 
-    static ImmutableDigiroadStop of (String externalStopId,
-                                     String externalLinkId,
+    static ImmutableDigiroadStop of (String digiroadStopId,
+                                     String digiroadLinkId,
                                      DigiroadStopDirection directionOnInfralink,
-                                     String elyNumber,
+                                     int nationalId,
                                      Point location,
                                      Optional<String> nameFinnish,
                                      Optional<String> nameSwedish) {
         return ImmutableDigiroadStop.builder()
                 .directionOnInfraLink(directionOnInfralink)
-                .externalStopId(externalStopId)
-                .externalLinkId(externalLinkId)
-                .elyNumber(elyNumber)
+                .digiroadStopId(digiroadStopId)
+                .digiroadLinkId(digiroadLinkId)
+                .nationalId(nationalId)
                 .location(location)
                 .nameFinnish(nameFinnish)
                 .nameSwedish(nameSwedish)

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStop.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStop.java
@@ -1,0 +1,46 @@
+package fi.hsl.jore.importer.feature.digiroad.entity;
+
+import org.immutables.value.Value;
+import org.locationtech.jts.geom.Point;
+
+import java.util.Optional;
+
+/**
+ * Contains the information of a stop point which is read from
+ * the data imported from Digiroad.
+ */
+@Value.Immutable
+public interface DigiroadStop {
+
+    DigiroadStopDirection directionOnInfraLink();
+
+    String externalStopId();
+
+    String externalLinkId();
+
+    String elyNumber();
+
+    Point location();
+
+    Optional<String> nameFinnish();
+
+    Optional<String> nameSwedish();
+
+    static ImmutableDigiroadStop of (String externalStopId,
+                                     String externalLinkId,
+                                     DigiroadStopDirection directionOnInfralink,
+                                     String elyNumber,
+                                     Point location,
+                                     Optional<String> nameFinnish,
+                                     Optional<String> nameSwedish) {
+        return ImmutableDigiroadStop.builder()
+                .directionOnInfraLink(directionOnInfralink)
+                .externalStopId(externalStopId)
+                .externalLinkId(externalLinkId)
+                .elyNumber(elyNumber)
+                .location(location)
+                .nameFinnish(nameFinnish)
+                .nameSwedish(nameSwedish)
+                .build();
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStopDirection.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/entity/DigiroadStopDirection.java
@@ -1,0 +1,21 @@
+package fi.hsl.jore.importer.feature.digiroad.entity;
+
+/**
+ * Defines the direction of the stop on infrastructure link.
+ * Possible values are:
+ *
+ * <ul>
+ *     <li>
+ *         <code>BACKWARD</code>. The stop is against the digitizing direction
+ *         of the infrastructure link.
+ *     </li>
+ *     <li>
+ *         <code>FORWARD</code>. The stop is in the digitizing direction of the
+ *         infrastructure link.
+ *     </li>
+ * </ul>
+ */
+public enum DigiroadStopDirection {
+    BACKWARD,
+    FORWARD
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
@@ -1,0 +1,69 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class CsvDigiroadStopService implements DigiroadStopService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvDigiroadStopService.class);
+
+    private final Resource csvResource;
+    private final Map<String, DigiroadStop> digiroadStops;
+
+    @Autowired
+    public CsvDigiroadStopService(@Value("digiroad.stop.csv.file.path") final Resource csvResource) {
+        this.csvResource = csvResource;
+        this.digiroadStops = new HashMap<>();
+    }
+
+    @Override
+    public Optional<DigiroadStop> findByElyNumber(String elyNumber) {
+        DigiroadStop stop = digiroadStops.get(elyNumber);
+        if (stop == null) {
+            return Optional.empty();
+        }
+        else {
+            return Optional.of(stop);
+        }
+    }
+
+    @PostConstruct
+    void readStopsFromCsvFile() throws Exception {
+        if (!csvResource.exists()) {
+            LOGGER.error(
+                    "Cannot read Digiroad stops from the CSV File: {} because it doesn't exist",
+                    csvResource.getFilename()
+            );
+            return;
+        }
+
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(csvResource.getFile()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Optional<DigiroadStop> stopContainer = DigiroadStopFactory.fromCsvLine(line);
+
+                if (stopContainer.isPresent()) {
+                    DigiroadStop stop = stopContainer.get();
+                    digiroadStops.put(stop.elyNumber(), stop);
+                }
+                else {
+                    LOGGER.error("Cannot parse the information of a Digiroad stop from the line: {}", line);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
@@ -1,6 +1,8 @@
 package fi.hsl.jore.importer.feature.digiroad.service;
 
 import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,8 +13,6 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -21,23 +21,21 @@ public class CsvDigiroadStopService implements DigiroadStopService {
     private static final Logger LOGGER = LoggerFactory.getLogger(CsvDigiroadStopService.class);
 
     private final Resource csvResource;
-    private final Map<String, DigiroadStop> digiroadStops;
+
+    //This cannot be final because the io.vavr.collection.HashMap is immutable
+    //and .put() method returns a new map which contains the added value.
+    private Map<Integer, DigiroadStop> digiroadStops;
 
     @Autowired
     public CsvDigiroadStopService(@Value("digiroad.stop.csv.file.path") final Resource csvResource) {
         this.csvResource = csvResource;
-        this.digiroadStops = new HashMap<>();
+        this.digiroadStops = HashMap.empty();
     }
 
     @Override
-    public Optional<DigiroadStop> findByElyNumber(String elyNumber) {
-        DigiroadStop stop = digiroadStops.get(elyNumber);
-        if (stop == null) {
-            return Optional.empty();
-        }
-        else {
-            return Optional.of(stop);
-        }
+    public Optional<DigiroadStop> findByNationalId(final int nationalId) {
+        final DigiroadStop stop = digiroadStops.get(nationalId).getOrNull();
+        return Optional.ofNullable(stop);
     }
 
     @PostConstruct
@@ -50,15 +48,14 @@ public class CsvDigiroadStopService implements DigiroadStopService {
             return;
         }
 
-
         try (BufferedReader reader = new BufferedReader(new FileReader(csvResource.getFile()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                Optional<DigiroadStop> stopContainer = DigiroadStopFactory.fromCsvLine(line);
+                final Optional<DigiroadStop> stopContainer = DigiroadStopFactory.fromCsvLine(line);
 
                 if (stopContainer.isPresent()) {
-                    DigiroadStop stop = stopContainer.get();
-                    digiroadStops.put(stop.elyNumber(), stop);
+                    final DigiroadStop stop = stopContainer.get();
+                    digiroadStops = digiroadStops.put(stop.nationalId(), stop);
                 }
                 else {
                     LOGGER.error("Cannot parse the information of a Digiroad stop from the line: {}", line);

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactory.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactory.java
@@ -1,0 +1,129 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStopDirection;
+import fi.hsl.jore.importer.feature.jore3.util.JoreGeometryUtil;
+import org.geojson.GeoJsonObject;
+import org.geojson.LngLatAlt;
+import org.locationtech.jts.geom.Point;
+
+import java.util.Optional;
+
+/**
+ * An object mother class which creates new
+ * {@link DigiroadStop} objects.
+ */
+class DigiroadStopFactory {
+
+    private static final String CSV_SEPARATOR_CHARACTER = ";";
+    private static final String DIRECTION_AGAINST_DIGITIZING_DIRECTION = "backward";
+    private static final String DIRECTION_IN_DIGITIZING_DIRECTION = "forward";
+    private static final int VALID_LINE_COLUMN_COUNT = 8;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+
+    /**
+     * Parses the information of a {@link DigiroadStop} object
+     * from line which is read from a CSV file. The file must use
+     * a semicolon (;) as a separator character. The line must contain
+     * the following columns in this order:
+     *<ul>
+     *     <li>The external id of the stop.</li>
+     *     <li>The external id of the infrastructure link</li>
+     *     <li>The national stop id (aka ely number)</li>
+     *     <li>The stop direction on the infrastructure link</li>
+     *     <li>The location of the stop</li>
+     *     <li>The Finnish name of the stop</li>
+     *     <li>The Swedish name of the stop</li>
+     *     <li>The source system</li>
+     *</ul>
+     *
+     *
+     * @param line
+     * @return
+     */
+    static Optional<DigiroadStop> fromCsvLine(String line) {
+        if (line == null) {
+            throw new NullPointerException("Line cannot be null");
+        }
+
+        String[] columns = line.split(CSV_SEPARATOR_CHARACTER);
+        if (columns.length != VALID_LINE_COLUMN_COUNT) {
+            throw new IllegalArgumentException(String.format(
+                    "Expected the line to have %d columns but had %d",
+                    VALID_LINE_COLUMN_COUNT,
+                    columns.length
+            ));
+        }
+
+        DigiroadStop stop = DigiroadStop.of(
+                parseRequiredField("externalStopId", columns[0].trim()),
+                parseRequiredField("externalLinkId", columns[1].trim()),
+                parseDirection(columns[3]),
+                parseRequiredField("elyNumber", columns[2]),
+                parseLocation(columns[4]),
+                getStringContainer(columns[5]),
+                getStringContainer(columns[6])
+        );
+        return Optional.of(stop);
+    }
+
+    private static Optional<String> getStringContainer(String value) {
+        if (value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(value.trim());
+    }
+
+    private static DigiroadStopDirection parseDirection(String value) {
+        String trimmedValue = value.trim();
+        switch(trimmedValue) {
+            case DIRECTION_IN_DIGITIZING_DIRECTION:
+                return DigiroadStopDirection.FORWARD;
+            case DIRECTION_AGAINST_DIGITIZING_DIRECTION:
+                return DigiroadStopDirection.BACKWARD;
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Unknown direction: %s",
+                        value
+                ));
+        }
+    }
+
+    private static Point parseLocation(String value) {
+        try {
+            org.geojson.Point point = (org.geojson.Point) OBJECT_MAPPER.readValue(
+                    removeExtraQuotationMarks(value.trim()),
+                    GeoJsonObject.class
+            );
+            LngLatAlt coordinates = point.getCoordinates();
+            return JoreGeometryUtil.fromDbCoordinates(coordinates.getLatitude(), coordinates.getLongitude());
+        }
+        catch (JsonProcessingException ex) {
+            throw new RuntimeException(String.format("Couldn't parse location from value: %s", value), ex);
+        }
+    }
+
+    private static String parseRequiredField(String fieldName, String source) {
+        String value = source.trim();
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(String.format("%s cannot be empty or contain only white space", fieldName));
+        }
+
+        return value;
+    }
+
+
+    /**
+     * Transforms the value: "{""type"": ""Point"", ""coordinates"": [24.696376131, 60.207149801]}" to value:
+     * {"type": "Point", "coordinates": [24.696376131, 60.207149801]}
+     */
+    private static String removeExtraQuotationMarks(String value) {
+        String valueWithoutExtraQuotationMarks = value.substring(1, value.length() - 1);
+        return valueWithoutExtraQuotationMarks.replaceAll("\"\"", "\"");
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopService.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopService.java
@@ -11,11 +11,11 @@ import java.util.Optional;
 public interface DigiroadStopService {
 
     /**
-     * Finds the information of a Digiroad stop by using ely number (national id)
+     * Finds the information of a Digiroad stop by using the national id
      * as search criteria.
-     * @param elyNumber The national identifier of a stop.
+     * @param nationalId The national identifier of a stop.
      * @return  An {@link Optional} object which contains the found {@link DigiroadStop}
-     *          object. If no stop point is found, this method returns an empty {@link Optional}.
+     *          object. If no stop is found, this method returns an empty {@link Optional}.
      */
-    Optional<DigiroadStop> findByElyNumber(String elyNumber);
+    Optional<DigiroadStop> findByNationalId(final int nationalId);
 }

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopService.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopService.java
@@ -1,0 +1,21 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+
+import java.util.Optional;
+
+/**
+ * Declares a method which which is used to get the Digiroad information
+ * of a stop point.
+ */
+public interface DigiroadStopService {
+
+    /**
+     * Finds the information of a Digiroad stop by using ely number (national id)
+     * as search criteria.
+     * @param elyNumber The national identifier of a stop.
+     * @return  An {@link Optional} object which contains the found {@link DigiroadStop}
+     *          object. If no stop point is found, this method returns an empty {@link Optional}.
+     */
+    Optional<DigiroadStop> findByElyNumber(String elyNumber);
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/jore3/util/StringParserUtil.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/jore3/util/StringParserUtil.java
@@ -1,0 +1,53 @@
+package fi.hsl.jore.importer.feature.jore3.util;
+
+/**
+ * Contains utility methods which help us to parse different
+ * values from {@link String} objects.
+ */
+public final class StringParserUtil {
+
+    /**
+     * Trims the source value and ensures that the source is not null
+     * and blank.
+     * @param alias     The alias of the returned value.
+     * @param source    The source value.
+     * @return          A value that doesn't contain any white space.
+     * @throws NullPointerException if the source value is {@code null}.
+     * @throws IllegalArgumentException if the source value is blank.
+     */
+    public static String parseRequiredValue(final String alias, final String source) {
+        if (source == null) {
+            throw new NullPointerException(String.format("%s cannot be null", alias));
+        }
+
+        final String value = source.trim();
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(String.format("%s cannot be empty or contain only white space", alias));
+        }
+
+        return value;
+    }
+
+    /**
+     * Parses an {@code int} value from the source value.
+     * @param alias     The alias of the returned value.
+     * @param source    The source value.
+     * @return          The parsed int value.
+     * @throws NullPointerException if the source value is {@code null}.
+     * @throws IllegalArgumentException if the source value is blank or it cannot be parsed.
+     */
+    public static int parseRequiredInteger(final String alias, final String source) {
+        final String value = parseRequiredValue(alias, source);
+        try {
+            return Integer.parseInt(value);
+        }
+        catch (final NumberFormatException ex) {
+            throw new IllegalArgumentException(
+                    String.format("Cannot parse integer value for field: %s from source value: %s",
+                            alias,
+                            value
+                    )
+            );
+        }
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPoint.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPoint.java
@@ -1,0 +1,36 @@
+package fi.hsl.jore.importer.feature.transmodel.entity;
+
+import org.immutables.value.Value;
+import org.locationtech.jts.geom.Point;
+
+/**
+ * Contains the information of a scheduled stop point which
+ * can be written to the Jore 4 transmodel schema.
+ */
+@Value.Immutable
+public interface TransmodelScheduledStopPoint {
+
+    String externalInfrastructureLinkId();
+
+    String externalScheduledStopPointId();
+
+    boolean isDirectionForwardOnInfraLink();
+
+    String label();
+
+    Point measuredLocation();
+
+    static ImmutableTransmodelScheduledStopPoint of (String externalScheduledStopPointId,
+                                                     String externalInfrastructureLinkId,
+                                                     boolean isDirectionForwardOnInfraLink,
+                                                     String label,
+                                                     Point measuredLocation) {
+        return ImmutableTransmodelScheduledStopPoint.builder()
+                .externalScheduledStopPointId(externalScheduledStopPointId)
+                .externalInfrastructureLinkId(externalInfrastructureLinkId)
+                .isDirectionForwardOnInfraLink(isDirectionForwardOnInfraLink)
+                .label(label)
+                .measuredLocation(measuredLocation)
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,7 @@ spring.batch.job.enabled=false
 
 # Enable only the health endpoint for actuator
 management.endpoints.web.exposure.include=health
+
+# The location of the CSV file which contains the information
+# of stops imported from Digiroad.
+digiroad.stop.csv.file.path=@digiroad.stop.csv.file.path@

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
@@ -1,0 +1,153 @@
+package fi.hsl.jore.importer.feature.batch.scheduled_stop_point;
+
+import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
+import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
+import fi.hsl.jore.importer.feature.digiroad.service.DigiroadStopService;
+import fi.hsl.jore.importer.feature.digiroad.service.TestCsvDigiroadStopServiceFactory;
+import fi.hsl.jore.importer.feature.jore3.util.JoreGeometryUtil;
+import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
+import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPoint;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ScheduledStopPointExportProcessorTest {
+
+    private final String LANGUAGE_CODE_FINNISH = "fi_FI";
+    private final String LANGUAGE_CODE_SWEDISH = "sv_SE";
+
+    private final String ELY_NUMBER = "168626";
+
+    private final String DIGIROAD_STOP_INFRA_LINK_ID = "133202";
+
+    private final String JORE_3_STOP_EXTERNAL_ID = "1234567";
+    private final String JORE_3_STOP_FINNISH_NAME = "Ullanmäki (Jore3)";
+    private final String JORE_3_STOP_SWEDISH_NAME = "Ullasbacken (Jore3)";
+    private final double JORE_3_STOP_X_COORDINATE = 25.696376131;
+    private final double JORE_3_STOP_Y_COORDINATE = 61.207149801;
+
+    private ScheduledStopPointExportProcessor processor;
+
+    @BeforeAll
+    void configureSystemUnderTest() throws Exception {
+        DigiroadStopService digiroadStopService = TestCsvDigiroadStopServiceFactory.create();
+        processor = new ScheduledStopPointExportProcessor(digiroadStopService);
+    }
+
+    @Nested
+    @DisplayName("When the source stop has no ely number")
+    class WhenSourceStopHasNoElyNumber {
+
+        private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                Optional.empty(),
+                JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                MultilingualString.of(Map.of(
+                        LANGUAGE_CODE_FINNISH,
+                        JORE_3_STOP_FINNISH_NAME,
+                        LANGUAGE_CODE_SWEDISH,
+                        JORE_3_STOP_SWEDISH_NAME
+                ))
+        );
+
+        @Test
+        @DisplayName("Should return null")
+        void shouldReturnNull() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("When no Digiroad stop is found with the ely number of the source stop")
+    class WhenNoDigiroadStopIsFoundWithElyNumberOfSourceStop {
+
+        private static final String UNKNOWN_ELY_NUMBER = "999999";
+
+        private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                Optional.of(UNKNOWN_ELY_NUMBER),
+                JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                MultilingualString.of(Map.of(
+                        LANGUAGE_CODE_FINNISH,
+                        JORE_3_STOP_FINNISH_NAME,
+                        LANGUAGE_CODE_SWEDISH,
+                        JORE_3_STOP_SWEDISH_NAME
+                ))
+        );
+
+        @Test
+        @DisplayName("Should return null")
+        void shouldReturnNull() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("When a Digiroad stop is found with the ely number of the source stop")
+    class WhenDigiroadStopIsFoundWithElyNumberOfSourceStop {
+
+        private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                Optional.of(ELY_NUMBER),
+                JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                MultilingualString.of(Map.of(
+                        LANGUAGE_CODE_FINNISH,
+                        JORE_3_STOP_FINNISH_NAME,
+                        LANGUAGE_CODE_SWEDISH,
+                        JORE_3_STOP_SWEDISH_NAME
+                ))
+        );
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct external stop id")
+        void shouldReturnScheduledStopPointWithCorrectExternalStopId() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.externalScheduledStopPointId()).isEqualTo(JORE_3_STOP_EXTERNAL_ID);
+        }
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct external infrastructure link id")
+        void shouldReturnScheduledStopPointWithCorrectExternalInfrastructureLinkId() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.externalInfrastructureLinkId()).isEqualTo(DIGIROAD_STOP_INFRA_LINK_ID);
+        }
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct stop direction")
+        void shouldReturnScheduledStopPointWithCorrectStopDirection() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.isDirectionForwardOnInfraLink()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct label")
+        void shouldReturnScheduledStopPointWithCorrectLabel() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.label()).isEqualTo(JORE_3_STOP_FINNISH_NAME);
+        }
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct X coordinate")
+        void shouldReturnScheduledStopPointWithCorrectXCoordinate() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.measuredLocation().getX()).isEqualTo(JORE_3_STOP_X_COORDINATE);
+        }
+
+        @Test
+        @DisplayName("Should return a scheduled stop point with the correct Y coordinate")
+        void shouldReturnScheduledStopPointWithCorrectYCoordinate() throws Exception {
+            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            assertThat(output.measuredLocation().getY()).isEqualTo(JORE_3_STOP_Y_COORDINATE);
+        }
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
@@ -38,7 +38,7 @@ class ScheduledStopPointExportProcessorTest {
 
     @BeforeAll
     void configureSystemUnderTest() throws Exception {
-        DigiroadStopService digiroadStopService = TestCsvDigiroadStopServiceFactory.create();
+        final DigiroadStopService digiroadStopService = TestCsvDigiroadStopServiceFactory.create();
         processor = new ScheduledStopPointExportProcessor(digiroadStopService);
     }
 
@@ -61,7 +61,7 @@ class ScheduledStopPointExportProcessorTest {
         @Test
         @DisplayName("Should return null")
         void shouldReturnNull() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output).isNull();
         }
     }
@@ -87,7 +87,7 @@ class ScheduledStopPointExportProcessorTest {
         @Test
         @DisplayName("Should return null")
         void shouldReturnNull() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output).isNull();
         }
     }
@@ -111,42 +111,42 @@ class ScheduledStopPointExportProcessorTest {
         @Test
         @DisplayName("Should return a scheduled stop point with the correct external stop id")
         void shouldReturnScheduledStopPointWithCorrectExternalStopId() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.externalScheduledStopPointId()).isEqualTo(JORE_3_STOP_EXTERNAL_ID);
         }
 
         @Test
         @DisplayName("Should return a scheduled stop point with the correct external infrastructure link id")
         void shouldReturnScheduledStopPointWithCorrectExternalInfrastructureLinkId() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.externalInfrastructureLinkId()).isEqualTo(DIGIROAD_STOP_INFRA_LINK_ID);
         }
 
         @Test
         @DisplayName("Should return a scheduled stop point with the correct stop direction")
         void shouldReturnScheduledStopPointWithCorrectStopDirection() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.isDirectionForwardOnInfraLink()).isFalse();
         }
 
         @Test
         @DisplayName("Should return a scheduled stop point with the correct label")
         void shouldReturnScheduledStopPointWithCorrectLabel() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.label()).isEqualTo(JORE_3_STOP_FINNISH_NAME);
         }
 
         @Test
         @DisplayName("Should return a scheduled stop point with the correct X coordinate")
         void shouldReturnScheduledStopPointWithCorrectXCoordinate() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.measuredLocation().getX()).isEqualTo(JORE_3_STOP_X_COORDINATE);
         }
 
         @Test
         @DisplayName("Should return a scheduled stop point with the correct Y coordinate")
         void shouldReturnScheduledStopPointWithCorrectYCoordinate() throws Exception {
-            TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
             assertThat(output.measuredLocation().getY()).isEqualTo(JORE_3_STOP_Y_COORDINATE);
         }
     }

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopServiceTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopServiceTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 
 import java.util.Optional;
 
@@ -26,111 +24,116 @@ class CsvDigiroadStopServiceTest {
     }
 
     @Nested
-    @DisplayName("When the digiroad stop is found")
-    class WhenDigiroadStopIsFound {
+    @DisplayName("Find by national id")
+    class FindByNationalId {
 
-        private final String EXPECTED_EXTERNAL_STOP_ID  = "111";
-        private final String EXPECTED_EXTERNAL_LINK_ID = "133202";
-        private final String ELY_NUMBER = "168626";
-        private final DigiroadStopDirection EXPECTED_DIRECTION_ON_INFRALINK = DigiroadStopDirection.BACKWARD;
-        private final double EXPECTED_X_COORDINATE = 24.696376131;
-        private final double EXPECTED_Y_COORDINATE = 60.207149801;
-        private final String EXPECTED_FINNISH_NAME = "Ullanmäki";
-        private final String EXPECTED_SWEDISH_NAME = "Ullasbacken";
+        @Nested
+        @DisplayName("When the digiroad stop is found")
+        class WhenDigiroadStopIsFound {
 
-        @Test
-        @DisplayName("Should return an optional which contains the parsed stop")
-        void shouldReturnOptionalWhichContainsParsedStop() {
-            Optional<DigiroadStop> container = service.findByElyNumber(ELY_NUMBER);
-            assertThat(container).isNotEmpty();
+            private final String EXPECTED_DIGIROAD_STOP_ID = "111";
+            private final String EXPECTED_DIGIROAD_LINK_ID = "133202";
+            private final int NATIONAL_ID = 168626;
+            private final DigiroadStopDirection EXPECTED_DIRECTION_ON_INFRALINK = DigiroadStopDirection.BACKWARD;
+            private final double EXPECTED_X_COORDINATE = 24.696376131;
+            private final double EXPECTED_Y_COORDINATE = 60.207149801;
+            private final String EXPECTED_FINNISH_NAME = "Ullanmäki";
+            private final String EXPECTED_SWEDISH_NAME = "Ullasbacken";
+
+            @Test
+            @DisplayName("Should return an optional which contains the parsed stop")
+            void shouldReturnOptionalWhichContainsParsedStop() {
+                final Optional<DigiroadStop> container = service.findByNationalId(NATIONAL_ID);
+                assertThat(container).isNotEmpty();
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct digiroad stop id")
+            void shouldReturnStopWhichContainsHasDigiroadStopId() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.digiroadStopId())
+                        .as("digiroadStopId")
+                        .isEqualTo(EXPECTED_DIGIROAD_STOP_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct digiroadLinkId")
+            void shouldReturnStopWhichHasCorrectDigiroadLinkId() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.digiroadLinkId())
+                        .as("digiroadLinkId")
+                        .isEqualTo(EXPECTED_DIGIROAD_LINK_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct nationalId")
+            void shouldReturnStopWhichHasCorrectElyNumber() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.nationalId())
+                        .as("nationalId")
+                        .isEqualTo(NATIONAL_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct direction on infra link")
+            void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.directionOnInfraLink())
+                        .as("directionOnInfraLink")
+                        .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct X coordinate")
+            void shouldReturnStopWhichHasCorrectXCoordinate() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.location().getX())
+                        .as("X Coordinate")
+                        .isEqualTo(EXPECTED_X_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Y coordinate")
+            void shouldReturnStopWhichHasCorrectYCoordinate() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.location().getY())
+                        .as("Y Coordinate")
+                        .isEqualTo(EXPECTED_Y_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Finnish name")
+            void shouldReturnStopWhichHasCorrectFinnishName() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.nameFinnish())
+                        .as("nameFinnish")
+                        .isNotEmpty()
+                        .contains(EXPECTED_FINNISH_NAME);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Swedish name")
+            void shouldReturnStopWhichHasCorrectSwedishName() {
+                final DigiroadStop stop = service.findByNationalId(NATIONAL_ID).get();
+                assertThat(stop.nameSwedish())
+                        .as("nameSwedish")
+                        .isNotEmpty()
+                        .contains(EXPECTED_SWEDISH_NAME);
+            }
         }
 
-        @Test
-        @DisplayName("Should return a stop which has the correct external stop id")
-        void shouldReturnStopWhichContainsHasExternalStopId() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.externalStopId())
-                    .as("externalStopId")
-                    .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
-        }
+        @Nested
+        @DisplayName("When no Digiroad stop is found")
+        class WhenNoDigiroadStopIsFound {
 
-        @Test
-        @DisplayName("Should return a stop which has the correct externalLinkId")
-        void shouldReturnStopWhichHasCorrectExternalLinkId() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.externalLinkId())
-                    .as("externalLinkId")
-                    .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
-        }
+            private final int UNKNOWN_NATIONAL_ID = 9876543;
 
-        @Test
-        @DisplayName("Should return a stop which has the correct ely number")
-        void shouldReturnStopWhichHasCorrectElyNumber() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.elyNumber())
-                    .as("elyNumber")
-                    .isEqualTo(ELY_NUMBER);
-        }
-
-        @Test
-        @DisplayName("Should return a stop which has the correct direction on infra link")
-        void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.directionOnInfraLink())
-                    .as("directionOnInfraLink")
-                    .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
-        }
-
-        @Test
-        @DisplayName("Should return a stop which has the correct X coordinate")
-        void shouldReturnStopWhichHasCorrectXCoordinate() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.location().getX())
-                    .as("X Coordinate")
-                    .isEqualTo(EXPECTED_X_COORDINATE);
-        }
-
-        @Test
-        @DisplayName("Should return a stop which has the correct Y coordinate")
-        void shouldReturnStopWhichHasCorrectYCoordinate() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.location().getY())
-                    .as("Y Coordinate")
-                    .isEqualTo(EXPECTED_Y_COORDINATE);
-        }
-
-        @Test
-        @DisplayName("Should return a stop which has the correct Finnish name")
-        void shouldReturnStopWhichHasCorrectFinnishName() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.nameFinnish())
-                    .as("nameFinnish")
-                    .isNotEmpty()
-                    .contains(EXPECTED_FINNISH_NAME);
-        }
-
-        @Test
-        @DisplayName("Should return a stop which has the correct Swedish name")
-        void shouldReturnStopWhichHasCorrectSwedishName() {
-            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
-            assertThat(stop.nameSwedish())
-                    .as("nameSwedish")
-                    .isNotEmpty()
-                    .contains(EXPECTED_SWEDISH_NAME);
-        }
-    }
-
-    @Nested
-    @DisplayName("When no Digiroad stop is found")
-    class WhenNoDigiroadStopIsFound {
-
-        private final String UNKNOWN_ELY_NUMBER = "9876543";
-
-        @Test
-        @DisplayName("Should return an empty optional")
-        void shouldReturnEmptyOptional() {
-            Optional<DigiroadStop> container = service.findByElyNumber(UNKNOWN_ELY_NUMBER);
-            assertThat(container).isEmpty();
+            @Test
+            @DisplayName("Should return an empty optional")
+            void shouldReturnEmptyOptional() {
+                final Optional<DigiroadStop> container = service.findByNationalId(UNKNOWN_NATIONAL_ID);
+                assertThat(container).isEmpty();
+            }
         }
     }
 }

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopServiceTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopServiceTest.java
@@ -1,0 +1,136 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStopDirection;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CsvDigiroadStopServiceTest {
+
+
+    private CsvDigiroadStopService service;
+
+    @BeforeAll
+    void configureSystemUnderTest() throws Exception {
+        service = TestCsvDigiroadStopServiceFactory.create();
+    }
+
+    @Nested
+    @DisplayName("When the digiroad stop is found")
+    class WhenDigiroadStopIsFound {
+
+        private final String EXPECTED_EXTERNAL_STOP_ID  = "111";
+        private final String EXPECTED_EXTERNAL_LINK_ID = "133202";
+        private final String ELY_NUMBER = "168626";
+        private final DigiroadStopDirection EXPECTED_DIRECTION_ON_INFRALINK = DigiroadStopDirection.BACKWARD;
+        private final double EXPECTED_X_COORDINATE = 24.696376131;
+        private final double EXPECTED_Y_COORDINATE = 60.207149801;
+        private final String EXPECTED_FINNISH_NAME = "Ullanmäki";
+        private final String EXPECTED_SWEDISH_NAME = "Ullasbacken";
+
+        @Test
+        @DisplayName("Should return an optional which contains the parsed stop")
+        void shouldReturnOptionalWhichContainsParsedStop() {
+            Optional<DigiroadStop> container = service.findByElyNumber(ELY_NUMBER);
+            assertThat(container).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct external stop id")
+        void shouldReturnStopWhichContainsHasExternalStopId() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.externalStopId())
+                    .as("externalStopId")
+                    .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct externalLinkId")
+        void shouldReturnStopWhichHasCorrectExternalLinkId() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.externalLinkId())
+                    .as("externalLinkId")
+                    .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct ely number")
+        void shouldReturnStopWhichHasCorrectElyNumber() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.elyNumber())
+                    .as("elyNumber")
+                    .isEqualTo(ELY_NUMBER);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct direction on infra link")
+        void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.directionOnInfraLink())
+                    .as("directionOnInfraLink")
+                    .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct X coordinate")
+        void shouldReturnStopWhichHasCorrectXCoordinate() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.location().getX())
+                    .as("X Coordinate")
+                    .isEqualTo(EXPECTED_X_COORDINATE);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct Y coordinate")
+        void shouldReturnStopWhichHasCorrectYCoordinate() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.location().getY())
+                    .as("Y Coordinate")
+                    .isEqualTo(EXPECTED_Y_COORDINATE);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct Finnish name")
+        void shouldReturnStopWhichHasCorrectFinnishName() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.nameFinnish())
+                    .as("nameFinnish")
+                    .isNotEmpty()
+                    .contains(EXPECTED_FINNISH_NAME);
+        }
+
+        @Test
+        @DisplayName("Should return a stop which has the correct Swedish name")
+        void shouldReturnStopWhichHasCorrectSwedishName() {
+            DigiroadStop stop = service.findByElyNumber(ELY_NUMBER).get();
+            assertThat(stop.nameSwedish())
+                    .as("nameSwedish")
+                    .isNotEmpty()
+                    .contains(EXPECTED_SWEDISH_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("When no Digiroad stop is found")
+    class WhenNoDigiroadStopIsFound {
+
+        private final String UNKNOWN_ELY_NUMBER = "9876543";
+
+        @Test
+        @DisplayName("Should return an empty optional")
+        void shouldReturnEmptyOptional() {
+            Optional<DigiroadStop> container = service.findByElyNumber(UNKNOWN_ELY_NUMBER);
+            assertThat(container).isEmpty();
+        }
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactoryTest.java
@@ -45,8 +45,8 @@ public class DigiroadStopFactoryTest {
         }
 
         @Nested
-        @DisplayName("When the external stop id is empty")
-        class WhenExternalStopIdIsEmpty {
+        @DisplayName("When the digiroad stop id is empty")
+        class WhenDigiroadStopIdIsEmpty {
 
             private static final String CSV_LINE = ";133202;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
 
@@ -59,8 +59,8 @@ public class DigiroadStopFactoryTest {
         }
 
         @Nested
-        @DisplayName("When the external link id is empty")
-        class WhenExternalLinkIdIsEmpty {
+        @DisplayName("When the digiroad link id is empty")
+        class WhenDigiroadLinkIdIsEmpty {
 
             private static final String CSV_LINE = "111;;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
 
@@ -73,10 +73,24 @@ public class DigiroadStopFactoryTest {
         }
 
         @Nested
-        @DisplayName("When the ely number is empty")
-        class WhenElyNumberIsEmpty {
+        @DisplayName("When the national id is empty")
+        class WhenNationalIdIsEmpty {
 
             private static final String CSV_LINE = "111;133202;;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the national id contains nonnumerical characters")
+        class WhenNationalIdIsContainsNonNumericalCharacters {
+
+            private static final String CSV_LINE = "111;133202;12d3;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
 
             @Test
             @DisplayName("Should throw an exception")
@@ -119,9 +133,9 @@ public class DigiroadStopFactoryTest {
     @DisplayName("When the CSV line is valid")
     class WhenCSVLineIsValid {
 
-        private final String EXPECTED_EXTERNAL_STOP_ID  = "111";
-        private final String EXPECTED_EXTERNAL_LINK_ID = "133202";
-        private final String EXPECTED_ELY_NUMBER = "168626";
+        private final String EXPECTED_DIGIROAD_STOP_ID = "111";
+        private final String EXPECTED_DIGIROAD_LINK_ID = "133202";
+        private final int EXPECTED_NATIONAL_ID = 168626;
         private final DigiroadStopDirection EXPECTED_DIRECTION_ON_INFRALINK = DigiroadStopDirection.BACKWARD;
         private final double EXPECTED_X_COORDINATE = 24.696376131;
         private final double EXPECTED_Y_COORDINATE = 60.207149801;
@@ -137,41 +151,41 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return an optional which contains the parsed stop")
             void shouldReturnOptionalWhichContainsParsedStop() {
-                Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
+                final Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
                 assertThat(container).isNotEmpty();
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct external stop id")
-            void shouldReturnStopWhichContainsHasExternalStopId() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.externalStopId())
-                        .as("externalStopId")
-                        .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
+            @DisplayName("Should return a stop which has the correct digiroad stop id")
+            void shouldReturnStopWhichHasCorrectDigiroadStopId() {
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.digiroadStopId())
+                        .as("digiroadStopId")
+                        .isEqualTo(EXPECTED_DIGIROAD_STOP_ID);
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct externalLinkId")
-            void shouldReturnStopWhichHasCorrectExternalLinkId() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.externalLinkId())
-                        .as("externalLinkId")
-                        .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
+            @DisplayName("Should return a stop which has the correct digiroadLinkId")
+            void shouldReturnStopWhichHasCorrectDigiroadLinkId() {
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.digiroadLinkId())
+                        .as("digiroadLinkId")
+                        .isEqualTo(EXPECTED_DIGIROAD_LINK_ID);
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct ely number")
+            @DisplayName("Should return a stop which has the correct national id")
             void shouldReturnStopWhichHasCorrectElyNumber() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.elyNumber())
-                        .as("elyNumber")
-                        .isEqualTo(EXPECTED_ELY_NUMBER);
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nationalId())
+                        .as("nationalId")
+                        .isEqualTo(EXPECTED_NATIONAL_ID);
             }
 
             @Test
             @DisplayName("Should return a stop which has the correct direction on infra link")
             void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.directionOnInfraLink())
                         .as("directionOnInfraLink")
                         .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
@@ -180,7 +194,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct X coordinate")
             void shouldReturnStopWhichHasCorrectXCoordinate() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.location().getX())
                         .as("X Coordinate")
                         .isEqualTo(EXPECTED_X_COORDINATE);
@@ -189,7 +203,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct Y coordinate")
             void shouldReturnStopWhichHasCorrectYCoordinate() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.location().getY())
                         .as("Y Coordinate")
                         .isEqualTo(EXPECTED_Y_COORDINATE);
@@ -198,7 +212,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct Finnish name")
             void shouldReturnStopWhichHasCorrectFinnishName() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.nameFinnish())
                         .as("nameFinnish")
                         .isNotEmpty()
@@ -208,7 +222,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct Swedish name")
             void shouldReturnStopWhichHasCorrectSwedishName() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.nameSwedish())
                         .as("nameSwedish")
                         .isNotEmpty()
@@ -225,41 +239,41 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return an optional which contains the parsed stop")
             void shouldReturnOptionalWhichContainsParsedStop() {
-                Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
+                final Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
                 assertThat(container).isNotEmpty();
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct external stop id")
-            void shouldReturnStopWhichContainsHasExternalStopId() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.externalStopId())
-                        .as("externalStopId")
-                        .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
+            @DisplayName("Should return a stop which has the correct digiroad stop id")
+            void shouldReturnStopWhichContainsHasDigiroadStopId() {
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.digiroadStopId())
+                        .as("digiroadStopId")
+                        .isEqualTo(EXPECTED_DIGIROAD_STOP_ID);
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct externalLinkId")
-            void shouldReturnStopWhichHasCorrectExternalLinkId() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.externalLinkId())
-                        .as("externalLinkId")
-                        .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
+            @DisplayName("Should return a stop which has the correct digiroadLinkId")
+            void shouldReturnStopWhichHasCorrectDigiroadLinkId() {
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.digiroadLinkId())
+                        .as("digiroadLinkId")
+                        .isEqualTo(EXPECTED_DIGIROAD_LINK_ID);
             }
 
             @Test
-            @DisplayName("Should return a stop which has the correct ely number")
-            void shouldReturnStopWhichHasCorrectElyNumber() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
-                assertThat(stop.elyNumber())
-                        .as("elyNumber")
-                        .isEqualTo(EXPECTED_ELY_NUMBER);
+            @DisplayName("Should return a stop which has the correct national id")
+            void shouldReturnStopWhichHasCorrectNationalId() {
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nationalId())
+                        .as("nationalId")
+                        .isEqualTo(EXPECTED_NATIONAL_ID);
             }
 
             @Test
             @DisplayName("Should return a stop which has the correct direction on infra link")
             void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.directionOnInfraLink())
                         .as("directionOnInfraLink")
                         .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
@@ -268,7 +282,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct X coordinate")
             void shouldReturnStopWhichHasCorrectXCoordinate() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.location().getX())
                         .as("X Coordinate")
                         .isEqualTo(EXPECTED_X_COORDINATE);
@@ -277,7 +291,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has the correct Y coordinate")
             void shouldReturnStopWhichHasCorrectYCoordinate() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.location().getY())
                         .as("Y Coordinate")
                         .isEqualTo(EXPECTED_Y_COORDINATE);
@@ -286,7 +300,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has an empty Finnish name")
             void shouldReturnStopWhichHasEmptyFinnishName() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.nameFinnish())
                         .as("nameFinnish")
                         .isEmpty();
@@ -295,7 +309,7 @@ public class DigiroadStopFactoryTest {
             @Test
             @DisplayName("Should return a stop which has an empty Swedish name")
             void shouldReturnStopWhichHasEmptySwedishName() {
-                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                final DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
                 assertThat(stop.nameSwedish())
                         .as("nameSwedish")
                         .isEmpty();

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/DigiroadStopFactoryTest.java
@@ -1,0 +1,305 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStop;
+import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStopDirection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Parse Digiroad stop from a CSV line")
+public class DigiroadStopFactoryTest {
+
+    @Nested
+    @DisplayName("When the CSV line is invalid")
+    class WhenCSVLineIsInvalid {
+
+        @Nested
+        @DisplayName("When the CSV line is null")
+        class WhenCSVLineIsNull {
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(null))
+                        .isExactlyInstanceOf(NullPointerException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the column count of the CSV line isn't correct")
+        class WhenColumnCountOfCSVLineIsNotCorrect {
+
+            private static final String CSV_LINE = ",,,,,,,";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the external stop id is empty")
+        class WhenExternalStopIdIsEmpty {
+
+            private static final String CSV_LINE = ";133202;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the external link id is empty")
+        class WhenExternalLinkIdIsEmpty {
+
+            private static final String CSV_LINE = "111;;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the ely number is empty")
+        class WhenElyNumberIsEmpty {
+
+            private static final String CSV_LINE = "111;133202;;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the stop direction is invalid")
+        class WhenStopDirectionIsInvalid {
+
+            private static final String CSV_LINE = "111;133202;168626;invalid;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("When the stop location is invalid")
+        class WhenStopLocationIsInvalid {
+
+            private static final String CSV_LINE = "111;133202;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801])\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should throw an exception")
+            void shouldThrowException() {
+                assertThatThrownBy(() -> DigiroadStopFactory.fromCsvLine(CSV_LINE))
+                        .isExactlyInstanceOf(RuntimeException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("When the CSV line is valid")
+    class WhenCSVLineIsValid {
+
+        private final String EXPECTED_EXTERNAL_STOP_ID  = "111";
+        private final String EXPECTED_EXTERNAL_LINK_ID = "133202";
+        private final String EXPECTED_ELY_NUMBER = "168626";
+        private final DigiroadStopDirection EXPECTED_DIRECTION_ON_INFRALINK = DigiroadStopDirection.BACKWARD;
+        private final double EXPECTED_X_COORDINATE = 24.696376131;
+        private final double EXPECTED_Y_COORDINATE = 60.207149801;
+        private final String EXPECTED_FINNISH_NAME = "Ullanmäki";
+        private final String EXPECTED_SWEDISH_NAME = "Ullasbacken";
+
+        @Nested
+        @DisplayName("When all values are given")
+        class WhenAllValuesAreGiven {
+
+            private static final String CSV_LINE = "111;133202;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";Ullanmäki;Ullasbacken;digiroad_r";
+
+            @Test
+            @DisplayName("Should return an optional which contains the parsed stop")
+            void shouldReturnOptionalWhichContainsParsedStop() {
+                Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
+                assertThat(container).isNotEmpty();
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct external stop id")
+            void shouldReturnStopWhichContainsHasExternalStopId() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.externalStopId())
+                        .as("externalStopId")
+                        .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct externalLinkId")
+            void shouldReturnStopWhichHasCorrectExternalLinkId() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.externalLinkId())
+                        .as("externalLinkId")
+                        .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct ely number")
+            void shouldReturnStopWhichHasCorrectElyNumber() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.elyNumber())
+                        .as("elyNumber")
+                        .isEqualTo(EXPECTED_ELY_NUMBER);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct direction on infra link")
+            void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.directionOnInfraLink())
+                        .as("directionOnInfraLink")
+                        .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct X coordinate")
+            void shouldReturnStopWhichHasCorrectXCoordinate() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.location().getX())
+                        .as("X Coordinate")
+                        .isEqualTo(EXPECTED_X_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Y coordinate")
+            void shouldReturnStopWhichHasCorrectYCoordinate() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.location().getY())
+                        .as("Y Coordinate")
+                        .isEqualTo(EXPECTED_Y_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Finnish name")
+            void shouldReturnStopWhichHasCorrectFinnishName() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nameFinnish())
+                        .as("nameFinnish")
+                        .isNotEmpty()
+                        .contains(EXPECTED_FINNISH_NAME);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Swedish name")
+            void shouldReturnStopWhichHasCorrectSwedishName() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nameSwedish())
+                        .as("nameSwedish")
+                        .isNotEmpty()
+                        .contains(EXPECTED_SWEDISH_NAME);
+            }
+        }
+
+        @Nested
+        @DisplayName("When names are empty strings")
+        class WhenNamesAreEmptyStrings {
+
+            private static final String CSV_LINE = "111;133202;168626;backward;\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [24.696376131, 60.207149801]}\";;;digiroad_r";
+
+            @Test
+            @DisplayName("Should return an optional which contains the parsed stop")
+            void shouldReturnOptionalWhichContainsParsedStop() {
+                Optional<DigiroadStop> container = DigiroadStopFactory.fromCsvLine(CSV_LINE);
+                assertThat(container).isNotEmpty();
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct external stop id")
+            void shouldReturnStopWhichContainsHasExternalStopId() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.externalStopId())
+                        .as("externalStopId")
+                        .isEqualTo(EXPECTED_EXTERNAL_STOP_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct externalLinkId")
+            void shouldReturnStopWhichHasCorrectExternalLinkId() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.externalLinkId())
+                        .as("externalLinkId")
+                        .isEqualTo(EXPECTED_EXTERNAL_LINK_ID);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct ely number")
+            void shouldReturnStopWhichHasCorrectElyNumber() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.elyNumber())
+                        .as("elyNumber")
+                        .isEqualTo(EXPECTED_ELY_NUMBER);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct direction on infra link")
+            void shouldReturnStopWhichHasCorrectDirectionOnInfraLink() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.directionOnInfraLink())
+                        .as("directionOnInfraLink")
+                        .isEqualTo(EXPECTED_DIRECTION_ON_INFRALINK);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct X coordinate")
+            void shouldReturnStopWhichHasCorrectXCoordinate() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.location().getX())
+                        .as("X Coordinate")
+                        .isEqualTo(EXPECTED_X_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has the correct Y coordinate")
+            void shouldReturnStopWhichHasCorrectYCoordinate() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.location().getY())
+                        .as("Y Coordinate")
+                        .isEqualTo(EXPECTED_Y_COORDINATE);
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has an empty Finnish name")
+            void shouldReturnStopWhichHasEmptyFinnishName() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nameFinnish())
+                        .as("nameFinnish")
+                        .isEmpty();
+            }
+
+            @Test
+            @DisplayName("Should return a stop which has an empty Swedish name")
+            void shouldReturnStopWhichHasEmptySwedishName() {
+                DigiroadStop stop = DigiroadStopFactory.fromCsvLine(CSV_LINE).get();
+                assertThat(stop.nameSwedish())
+                        .as("nameSwedish")
+                        .isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/TestCsvDigiroadStopServiceFactory.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/TestCsvDigiroadStopServiceFactory.java
@@ -1,0 +1,15 @@
+package fi.hsl.jore.importer.feature.digiroad.service;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+public final class TestCsvDigiroadStopServiceFactory {
+
+    private static final Resource CSV_CLASSPATH_RESOURCE = new ClassPathResource("csv/digiroad_stops.csv");
+
+    public static CsvDigiroadStopService create() throws Exception {
+        CsvDigiroadStopService service = new CsvDigiroadStopService(CSV_CLASSPATH_RESOURCE);
+        service.readStopsFromCsvFile();
+        return service;
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/TestCsvDigiroadStopServiceFactory.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/digiroad/service/TestCsvDigiroadStopServiceFactory.java
@@ -8,7 +8,7 @@ public final class TestCsvDigiroadStopServiceFactory {
     private static final Resource CSV_CLASSPATH_RESOURCE = new ClassPathResource("csv/digiroad_stops.csv");
 
     public static CsvDigiroadStopService create() throws Exception {
-        CsvDigiroadStopService service = new CsvDigiroadStopService(CSV_CLASSPATH_RESOURCE);
+        final CsvDigiroadStopService service = new CsvDigiroadStopService(CSV_CLASSPATH_RESOURCE);
         service.readStopsFromCsvFile();
         return service;
     }

--- a/src/test/resources/csv/digiroad_stops.csv
+++ b/src/test/resources/csv/digiroad_stops.csv
@@ -1,0 +1,1 @@
+111;133202;168626;backward;"{""type"": ""Point"", ""coordinates"": [24.696376131, 60.207149801]}";Ullanmäki;Ullasbacken;digiroad_r


### PR DESCRIPTION
- Read the Digiroad stop information from a CSV file which
  is found from the file system.
- Implement a Spring Batch item proecssor which combines
  the stop information imported from Jore 3 and Digiroad,
  and created a new TransmodelScheduledStopPoint object
  which can be inserted into the Jore 4 database.
- Write tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/42)
<!-- Reviewable:end -->
