### PR TITLE
Replace direction boolean with an enum

### DIFF
--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
@@ -6,6 +6,7 @@ import fi.hsl.jore.importer.feature.digiroad.entity.DigiroadStopDirection;
 import fi.hsl.jore.importer.feature.digiroad.service.DigiroadStopService;
 import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPoint;
+import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPointDirection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
@@ -59,17 +60,13 @@ public class ScheduledStopPointExportProcessor implements ItemProcessor<Exportab
         final TransmodelScheduledStopPoint transmodelStop = TransmodelScheduledStopPoint.of(
                 jore3Stop.externalId().value(),
                 digiroadStop.digiroadLinkId(),
-                isDirectionForwardOnInfraLink(digiroadStop.directionOnInfraLink()),
+                TransmodelScheduledStopPointDirection.valueOf(digiroadStop.directionOnInfraLink().name()),
                 constructLabel(jore3Stop.name()),
                 jore3Stop.location()
         );
 
         LOGGER.debug("Created scheduled stop point: {}", transmodelStop);
         return transmodelStop;
-    }
-
-    private static boolean isDirectionForwardOnInfraLink(final DigiroadStopDirection stopDirection) {
-        return stopDirection == DigiroadStopDirection.FORWARD;
     }
 
     private static String constructLabel(final MultilingualString name) {

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPoint.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPoint.java
@@ -14,21 +14,21 @@ public interface TransmodelScheduledStopPoint {
 
     String externalScheduledStopPointId();
 
-    boolean isDirectionForwardOnInfraLink();
+    TransmodelScheduledStopPointDirection directionOnInfraLink();
 
     String label();
 
     Point measuredLocation();
 
-    static ImmutableTransmodelScheduledStopPoint of (String externalScheduledStopPointId,
-                                                     String externalInfrastructureLinkId,
-                                                     boolean isDirectionForwardOnInfraLink,
-                                                     String label,
-                                                     Point measuredLocation) {
+    static ImmutableTransmodelScheduledStopPoint of (final String externalScheduledStopPointId,
+                                                     final String externalInfrastructureLinkId,
+                                                     final TransmodelScheduledStopPointDirection directionOnInfraLink,
+                                                     final String label,
+                                                     final Point measuredLocation) {
         return ImmutableTransmodelScheduledStopPoint.builder()
                 .externalScheduledStopPointId(externalScheduledStopPointId)
                 .externalInfrastructureLinkId(externalInfrastructureLinkId)
-                .isDirectionForwardOnInfraLink(isDirectionForwardOnInfraLink)
+                .directionOnInfraLink(directionOnInfraLink)
                 .label(label)
                 .measuredLocation(measuredLocation)
                 .build();

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPointDirection.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/entity/TransmodelScheduledStopPointDirection.java
@@ -1,0 +1,24 @@
+package fi.hsl.jore.importer.feature.transmodel.entity;
+
+/**
+ * Specifies the direction of the scheduled stop point
+ * on an infrastructure link.
+ */
+public enum TransmodelScheduledStopPointDirection {
+
+    BACKWARD("backward"),
+    FORWARD("forward");
+
+    private final String value;
+
+    TransmodelScheduledStopPointDirection(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return The value which is inserted into the Jore 4 database.
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
@@ -7,6 +7,7 @@ import fi.hsl.jore.importer.feature.digiroad.service.TestCsvDigiroadStopServiceF
 import fi.hsl.jore.importer.feature.jore3.util.JoreGeometryUtil;
 import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableScheduledStopPoint;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPoint;
+import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPointDirection;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,6 +34,8 @@ class ScheduledStopPointExportProcessorTest {
     private final String JORE_3_STOP_SWEDISH_NAME = "Ullasbacken (Jore3)";
     private final double JORE_3_STOP_X_COORDINATE = 25.696376131;
     private final double JORE_3_STOP_Y_COORDINATE = 61.207149801;
+
+    private final TransmodelScheduledStopPointDirection TRANSMODEL_STOP_POINT_DIRECTION_ON_INFRA_LINK = TransmodelScheduledStopPointDirection.BACKWARD;
 
     private ScheduledStopPointExportProcessor processor;
 
@@ -126,7 +129,7 @@ class ScheduledStopPointExportProcessorTest {
         @DisplayName("Should return a scheduled stop point with the correct stop direction")
         void shouldReturnScheduledStopPointWithCorrectStopDirection() throws Exception {
             final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
-            assertThat(output.isDirectionForwardOnInfraLink()).isFalse();
+            assertThat(output.directionOnInfraLink()).isEqualTo(TRANSMODEL_STOP_POINT_DIRECTION_ON_INFRA_LINK);
         }
 
         @Test


### PR DESCRIPTION
Because the datatype of the direction column of the
internal_service_pattern.scheduled_stop_point table
is an "enum", this commit ensures that the scheduled
stop point which can be written to Jore4 database
uses an enum when it describes the direction of the
stop point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/46)
<!-- Reviewable:end -->
