### PR TITLE
Ensure that scheduled stop points can be transferred to Jore 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,20 @@ The following figure illustrates the responsibilities of these components:
 
 ![Overview](images/import_lines_step.svg "Step overview")
 
+### Importing Data to Jore 4
+
+#### Scheduled Stop Points
+
+The process that imports scheduled stop points to Jore 4 follows these rules:
+
+* The imported stop points are sorted in ascending the order by using the external id (Jore 3 id). If multiple scheduled
+  stop points have the same short id, the first one is transferred to Jore 4. This ensures that multiple stop points
+  with the same short id and validity period cannot be transferred to Jore 4.
+* If the ely number of a scheduled stop point isn't found from the database of the importer, it won't be transferred
+  to Jore 4.
+* If the information of a scheduled stop point isn't found from Digiroad, it won't be transferred to Jore 4.
+* The import process ignores Digiroad stop points which have invalid information (such missing or empty ely number).
+
 ## The Structure of the Project
 
 The directory structure of this project follows the [Maven directory layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html).

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessor.java
@@ -6,6 +6,7 @@ import fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto.ExportableS
 import fi.hsl.jore.importer.feature.transmodel.ExportConstants;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPoint;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelScheduledStopPointDirection;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
@@ -56,7 +57,7 @@ public class ScheduledStopPointExportProcessor implements ItemProcessor<Exportab
         LOGGER.debug("Processing Jore 3 stop: {}", jore3Stop);
 
         final String elyNumber = jore3Stop.elyNumber().filter(str -> !str.isEmpty()).orElse(null);
-        if (elyNumber == null) {
+        if (StringUtils.isBlank(elyNumber)) {
             LOGGER.debug("Jore 3 stop with id: {} isn't processed any further because it has no ely number",
                     jore3Stop.externalId().value()
             );

--- a/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/digiroad/service/CsvDigiroadStopService.java
@@ -46,17 +46,25 @@ public class CsvDigiroadStopService implements DigiroadStopService {
             return;
         }
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(csvResource.getFile()))) {
+        try (final BufferedReader reader = new BufferedReader(new FileReader(csvResource.getFile()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                final Optional<DigiroadStop> stopContainer = DigiroadStopFactory.fromCsvLine(line);
+                try {
+                    final Optional<DigiroadStop> stopContainer = DigiroadStopFactory.fromCsvLine(line);
 
-                if (stopContainer.isPresent()) {
-                    final DigiroadStop stop = stopContainer.get();
-                    digiroadStops = digiroadStops.put(stop.nationalId(), stop);
+                    if (stopContainer.isPresent()) {
+                        final DigiroadStop stop = stopContainer.get();
+                        digiroadStops = digiroadStops.put(stop.nationalId(), stop);
+                    }
+                    else {
+                        LOGGER.error("Cannot parse the information of a Digiroad stop from the line: {}", line);
+                    }
                 }
-                else {
-                    LOGGER.error("Cannot parse the information of a Digiroad stop from the line: {}", line);
+                catch (final Exception ex) {
+                    LOGGER.error("Cannot parse the information of a Digiroad stop from the line: {} because of an error: {}",
+                            line,
+                            ex.getMessage()
+                    );
                 }
             }
         }

--- a/src/main/resources/export/export_scheduled_stop_points.sql
+++ b/src/main/resources/export/export_scheduled_stop_points.sql
@@ -4,5 +4,10 @@ SELECT s.scheduled_stop_point_ext_id AS external_id,
        s.scheduled_stop_point_name AS name,
        s.scheduled_stop_point_short_id AS short_id
 FROM network.scheduled_stop_points s
-         JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = s.infrastructure_node_id)
+    JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = s.infrastructure_node_id)
 WHERE s.scheduled_stop_point_ely_number IS NOT NULL
+AND s.scheduled_stop_point_ext_id=(
+    SELECT MIN(sp.scheduled_stop_point_ext_id)
+    FROM network.scheduled_stop_points sp
+    where sp.scheduled_stop_point_short_id=s.scheduled_stop_point_short_id
+)

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/scheduled_stop_point/ScheduledStopPointExportProcessorTest.java
@@ -62,19 +62,64 @@ class ScheduledStopPointExportProcessorTest {
     @DisplayName("When the source stop has no ely number")
     class WhenSourceStopHasNoElyNumber {
 
-        private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
-                ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
-                Optional.empty(),
-                JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
-                JoreLocaleUtil.createMultilingualString(JORE_3_STOP_FINNISH_NAME, JORE_3_STOP_SWEDISH_NAME),
-                Optional.of(IMPORTER_SHORT_ID)
-        );
+        @Nested
+        @DisplayName("When the ely number is missing")
+        class WhenElyNumberIsMissing {
 
-        @Test
-        @DisplayName("Should return null")
-        void shouldReturnNull() throws Exception {
-            final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
-            assertThat(output).isNull();
+            private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                    ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                    Optional.empty(),
+                    JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                    JoreLocaleUtil.createMultilingualString(JORE_3_STOP_FINNISH_NAME, JORE_3_STOP_SWEDISH_NAME),
+                    Optional.of(IMPORTER_SHORT_ID)
+            );
+
+            @Test
+            @DisplayName("Should return null")
+            void shouldReturnNull() throws Exception {
+                final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+                assertThat(output).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("When the ely number is an empty string")
+        class WhenElyNumberIsEmptyString {
+
+            private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                    ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                    Optional.of(""),
+                    JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                    JoreLocaleUtil.createMultilingualString(JORE_3_STOP_FINNISH_NAME, JORE_3_STOP_SWEDISH_NAME),
+                    Optional.of(IMPORTER_SHORT_ID)
+            );
+
+            @Test
+            @DisplayName("Should return null")
+            void shouldReturnNull() throws Exception {
+                final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+                assertThat(output).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("When the ely number contains only white space")
+        class WhenElyNumberContainsOnlyWhiteSpace {
+
+            private final ExportableScheduledStopPoint jore3Stop = ExportableScheduledStopPoint.of(
+                    ExternalId.of(JORE_3_STOP_EXTERNAL_ID),
+                    Optional.of("     "),
+                    JoreGeometryUtil.fromDbCoordinates(JORE_3_STOP_Y_COORDINATE, JORE_3_STOP_X_COORDINATE),
+                    JoreLocaleUtil.createMultilingualString(JORE_3_STOP_FINNISH_NAME, JORE_3_STOP_SWEDISH_NAME),
+                    Optional.of(IMPORTER_SHORT_ID)
+            );
+
+            @Test
+            @DisplayName("Should return null")
+            void shouldReturnNull() throws Exception {
+                final TransmodelScheduledStopPoint output = processor.process(jore3Stop);
+                assertThat(output).isNull();
+            }
         }
     }
 


### PR DESCRIPTION
- Order transferred stop points in ascending order by using
  the external id of the stop point and transfer the information
  of the first stop point. This removes duplicate stop point from
  the list which is imported to Jore 4.
- Ignore errors (and log) errors caused by unknown scheduled
  stop point directions found from Digiroad.
- Ignore (and log) scheduled stop points who ely number is a
  blank string.
- Write more tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/64)
<!-- Reviewable:end -->
