### PR TITLE
Ensure that Jore 4 import can be run successfully

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -21,3 +21,4 @@ jobs:
         uses: HSLdevcom/jore4-tools/github-actions/healthcheck@healthcheck-v1
         with:
           command: "curl --fail http://localhost:3004/actuator/health --output /dev/null --silent"
+          retries: 50

--- a/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
+++ b/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
@@ -74,6 +74,7 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.FlowBuilder;
 import org.springframework.batch.core.job.flow.Flow;
 import org.springframework.batch.core.job.flow.support.SimpleFlow;
+import org.springframework.batch.core.step.skip.AlwaysSkipItemSkipPolicy;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -550,10 +551,12 @@ public class JobConfig extends BatchConfig {
                                               final ScheduledStopPointExportWriter writer) {
         return steps.get("exportScheduledStopPointsStep")
                 .allowStartIfComplete(true)
-                .<ExportableScheduledStopPoint, TransmodelScheduledStopPoint>chunk(1000)
+                .<ExportableScheduledStopPoint, TransmodelScheduledStopPoint>chunk(1)
                 .reader(reader.build())
                 .processor(processor)
                 .writer(writer)
+                .faultTolerant()
+                .skipPolicy(new AlwaysSkipItemSkipPolicy())
                 .build();
     }
 
@@ -563,10 +566,12 @@ public class JobConfig extends BatchConfig {
                                 final LineExportWriter writer) {
         return steps.get("exportLinesStep")
                 .allowStartIfComplete(true)
-                .<ExportableLine, TransmodelLine>chunk(1000)
+                .<ExportableLine, TransmodelLine>chunk(1)
                 .reader(reader.build())
                 .processor(processor)
                 .writer(writer)
+                .faultTolerant()
+                .skipPolicy(new AlwaysSkipItemSkipPolicy())
                 .build();
     }
 
@@ -576,10 +581,12 @@ public class JobConfig extends BatchConfig {
                                  final RouteExportWriter writer) {
         return steps.get("exportRoutesStep")
                 .allowStartIfComplete(true)
-                .<ExportableRoute, TransmodelRoute>chunk(1000)
+                .<ExportableRoute, TransmodelRoute>chunk(1)
                 .reader(reader.build())
                 .processor(processor)
                 .writer(writer)
+                .faultTolerant()
+                .skipPolicy(new AlwaysSkipItemSkipPolicy())
                 .build();
     }
 }

--- a/src/main/java/fi/hsl/jore/importer/config/jobs/LoggingAlwaysSkipPolicy.java
+++ b/src/main/java/fi/hsl/jore/importer/config/jobs/LoggingAlwaysSkipPolicy.java
@@ -1,0 +1,20 @@
+package fi.hsl.jore.importer.config.jobs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.step.skip.SkipLimitExceededException;
+import org.springframework.batch.core.step.skip.SkipPolicy;
+
+/**
+ * Skips every error and writes a message to the log.
+ */
+public class LoggingAlwaysSkipPolicy implements SkipPolicy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingAlwaysSkipPolicy.class);
+
+    @Override
+    public boolean shouldSkip(final Throwable throwable, final int skipCount) throws SkipLimitExceededException {
+        LOGGER.error("Could not process the item because an error occurred: {}", throwable.getMessage());
+        return true;
+    }
+}

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelLineRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelLineRepository.java
@@ -28,31 +28,33 @@ public class TransmodelLineRepository implements ITransmodelLineRepository {
 
     @Override
     public void insert(final List<? extends TransmodelLine> lines) {
-        final BatchBindStep batch = db.batch(db.insertInto(
-                LINE,
-                LINE.LINE_ID,
-                LINE.LABEL,
-                LINE.NAME_I18N,
-                LINE.PRIMARY_VEHICLE_MODE,
-                LINE.PRIORITY,
-                LINE.SHORT_NAME_I18N,
-                LINE.VALIDITY_START,
-                LINE.VALIDITY_END
-        )
-                .values((UUID) null, null, null, null, null, null, null, null)
-        );
+        if (!lines.isEmpty()) {
+            final BatchBindStep batch = db.batch(db.insertInto(
+                                    LINE,
+                                    LINE.LINE_ID,
+                                    LINE.LABEL,
+                                    LINE.NAME_I18N,
+                                    LINE.PRIMARY_VEHICLE_MODE,
+                                    LINE.PRIORITY,
+                                    LINE.SHORT_NAME_I18N,
+                                    LINE.VALIDITY_START,
+                                    LINE.VALIDITY_END
+                            )
+                            .values((UUID) null, null, null, null, null, null, null, null)
+            );
 
-        lines.forEach(line -> batch.bind(
-                line.lineId(),
-                line.label(),
-                jsonbConverter.asJson(line.name()),
-                line.primaryVehicleMode().getValue(),
-                line.priority(),
-                jsonbConverter.asJson(line.shortName()),
-                line.validityStart().orElse(null),
-                line.validityEnd().orElse(null)
-        ));
+            lines.forEach(line -> batch.bind(
+                    line.lineId(),
+                    line.label(),
+                    jsonbConverter.asJson(line.name()),
+                    line.primaryVehicleMode().getValue(),
+                    line.priority(),
+                    jsonbConverter.asJson(line.shortName()),
+                    line.validityStart().orElse(null),
+                    line.validityEnd().orElse(null)
+            ));
 
-        batch.execute();
+            batch.execute();
+        }
     }
 }

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelRouteRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelRouteRepository.java
@@ -30,35 +30,37 @@ public class TransmodelRouteRepository implements ITransmodelRouteRepository {
     @Transactional
     @Override
     public void insert(final List<? extends TransmodelRoute> routes) {
-        final BatchBindStep batch = db.batch(db.insertInto(
-                ROUTE,
-                ROUTE.ROUTE_ID,
-                ROUTE.DESCRIPTION_I18N,
-                ROUTE.DIRECTION,
-                ROUTE.LABEL,
-                ROUTE.ON_LINE_ID,
-                ROUTE.PRIORITY,
-                ROUTE.STARTS_FROM_SCHEDULED_STOP_POINT_ID,
-                ROUTE.ENDS_AT_SCHEDULED_STOP_POINT_ID,
-                ROUTE.VALIDITY_START,
-                ROUTE.VALIDITY_END
-        )
-                .values((UUID) null, null, null, null, null, null, null, null, null, null)
-        );
+        if (!routes.isEmpty()) {
+            final BatchBindStep batch = db.batch(db.insertInto(
+                                    ROUTE,
+                                    ROUTE.ROUTE_ID,
+                                    ROUTE.DESCRIPTION_I18N,
+                                    ROUTE.DIRECTION,
+                                    ROUTE.LABEL,
+                                    ROUTE.ON_LINE_ID,
+                                    ROUTE.PRIORITY,
+                                    ROUTE.STARTS_FROM_SCHEDULED_STOP_POINT_ID,
+                                    ROUTE.ENDS_AT_SCHEDULED_STOP_POINT_ID,
+                                    ROUTE.VALIDITY_START,
+                                    ROUTE.VALIDITY_END
+                            )
+                            .values((UUID) null, null, null, null, null, null, null, null, null, null)
+            );
 
-        routes.forEach(route -> batch.bind(
-                route.routeId(),
-                jsonbConverter.asJson(route.description()),
-                route.direction().getValue(),
-                route.label(),
-                route.lineId(),
-                route.priority(),
-                route.startScheduledStopPointId(),
-                route.endScheduledStopPointId(),
-                route.validityStart().orElse(null),
-                route.validityEnd().orElse(null)
-        ));
+            routes.forEach(route -> batch.bind(
+                    route.routeId(),
+                    jsonbConverter.asJson(route.description()),
+                    route.direction().getValue(),
+                    route.label(),
+                    route.lineId(),
+                    route.priority(),
+                    route.startScheduledStopPointId(),
+                    route.endScheduledStopPointId(),
+                    route.validityStart().orElse(null),
+                    route.validityEnd().orElse(null)
+            ));
 
-        batch.execute();
+            batch.execute();
+        }
     }
 }

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelScheduledStopPointRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelScheduledStopPointRepository.java
@@ -25,34 +25,36 @@ public class TransmodelScheduledStopPointRepository implements ITransmodelSchedu
 
     @Override
     public void insert(final List<? extends TransmodelScheduledStopPoint> stopPoints) {
-        final BatchBindStep batch = db.batch(db.insertInto(
-                SCHEDULED_STOP_POINT,
-                SCHEDULED_STOP_POINT.SCHEDULED_STOP_POINT_ID,
-                SCHEDULED_STOP_POINT.DIRECTION,
-                SCHEDULED_STOP_POINT.LABEL,
-                SCHEDULED_STOP_POINT.LOCATED_ON_INFRASTRUCTURE_LINK_ID,
-                SCHEDULED_STOP_POINT.MEASURED_LOCATION,
-                SCHEDULED_STOP_POINT.PRIORITY,
-                SCHEDULED_STOP_POINT.VALIDITY_START,
-                SCHEDULED_STOP_POINT.VALIDITY_END
-        )
-                        .values((UUID) null, null, null, null, null, null, null, null)
-        );
+        if (!stopPoints.isEmpty()) {
+            final BatchBindStep batch = db.batch(db.insertInto(
+                                    SCHEDULED_STOP_POINT,
+                                    SCHEDULED_STOP_POINT.SCHEDULED_STOP_POINT_ID,
+                                    SCHEDULED_STOP_POINT.DIRECTION,
+                                    SCHEDULED_STOP_POINT.LABEL,
+                                    SCHEDULED_STOP_POINT.LOCATED_ON_INFRASTRUCTURE_LINK_ID,
+                                    SCHEDULED_STOP_POINT.MEASURED_LOCATION,
+                                    SCHEDULED_STOP_POINT.PRIORITY,
+                                    SCHEDULED_STOP_POINT.VALIDITY_START,
+                                    SCHEDULED_STOP_POINT.VALIDITY_END
+                            )
+                            .values((UUID) null, null, null, null, null, null, null, null)
+            );
 
-        stopPoints.forEach(stopPoint -> batch.bind(
-                stopPoint.scheduledStopPointId(),
-                stopPoint.directionOnInfraLink().getValue(),
-                stopPoint.label(),
-                db.select(INFRASTRUCTURE_LINK.INFRASTRUCTURE_LINK_ID)
-                        .from(INFRASTRUCTURE_LINK)
-                        .where(INFRASTRUCTURE_LINK.EXTERNAL_LINK_ID.eq(stopPoint.externalInfrastructureLinkId()))
-                        .fetchOneInto(UUID.class),
-                stopPoint.measuredLocation(),
-                stopPoint.priority(),
-                stopPoint.validityStart().orElse(null),
-                stopPoint.validityEnd().orElse(null)
-        ));
+            stopPoints.forEach(stopPoint -> batch.bind(
+                    stopPoint.scheduledStopPointId(),
+                    stopPoint.directionOnInfraLink().getValue(),
+                    stopPoint.label(),
+                    db.select(INFRASTRUCTURE_LINK.INFRASTRUCTURE_LINK_ID)
+                            .from(INFRASTRUCTURE_LINK)
+                            .where(INFRASTRUCTURE_LINK.EXTERNAL_LINK_ID.eq(stopPoint.externalInfrastructureLinkId()))
+                            .fetchOneInto(UUID.class),
+                    stopPoint.measuredLocation(),
+                    stopPoint.priority(),
+                    stopPoint.validityStart().orElse(null),
+                    stopPoint.validityEnd().orElse(null)
+            ));
 
-        batch.execute();
+            batch.execute();
+        }
     }
 }

--- a/src/main/resources/export/export_routes.sql
+++ b/src/main/resources/export/export_routes.sql
@@ -3,21 +3,37 @@ SELECT r.network_route_ext_id AS external_id,
        r.network_route_number AS route_number,
        rd.network_route_direction_type AS direction_type,
        l.network_line_transmodel_id AS line_transmodel_id,
+       /*
+            Finds the first scheduled stop point of the exported route. Note that we must use
+            the split_part() function when we join the network.scheduled_stop_points and
+            network.network_route_stop_points tables because the value of the network_route_stop_point_ext_id
+            column of the network.network_route_stop_points table uses this format:
+
+            [the id of the route link]-[the external id of the scheduled stop point].
+        */
        (
            SELECT ssp.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points ssp
            JOIN network.network_route_stop_points rsp ON (split_part(rsp.network_route_stop_point_ext_id, '-', 2) = ssp.scheduled_stop_point_ext_id)
            JOIN network.network_route_points rp ON (rp.network_route_point_id = rsp.network_route_point_id)
            JOIN network.network_route_directions rd1 ON (rd1.network_route_direction_id = rp.network_route_direction_id)
-           WHERE rd1.network_route_id = r.network_route_id AND rp.network_route_direction_id = rd1.network_route_direction_id
-           ORDER BY rp.network_route_point_order ASC LIMIT 1
+           WHERE rd1.network_route_id = r.network_route_id AND rd1.network_route_direction_id = rd.network_route_direction_id
+           ORDER BY rsp.network_route_stop_point_order ASC LIMIT 1
        ) AS start_scheduled_stop_point_transmodel_id,
+       /*
+            Finds the last scheduled stop point of the exported route. Note that we must use
+            the split_part() function when we join the network.scheduled_stop_points and
+            network.network_route_stop_points tables because the value of the network_route_stop_point_ext_id
+            column of the network.network_route_stop_points table uses this format:
+
+            [the id of the route link]-[the external id of the scheduled stop point].
+        */
        (
            SELECT ssp.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points ssp
            JOIN network.network_route_stop_points rsp ON (split_part(rsp.network_route_stop_point_ext_id, '-', 2) = ssp.scheduled_stop_point_ext_id)
            JOIN network.network_route_points rp ON (rp.network_route_point_id = rsp.network_route_point_id)
-           JOIN network.network_route_directions rd1 ON (rd1.network_route_direction_id = rp.network_route_direction_id)
-           WHERE rd1.network_route_id = r.network_route_id AND rp.network_route_direction_id = rd1.network_route_direction_id
-           ORDER BY rp.network_route_point_order DESC LIMIT 1
+           JOIN network.network_route_directions rd2 ON (rd2.network_route_direction_id = rp.network_route_direction_id)
+           WHERE rd2.network_route_id = r.network_route_id AND rd2.network_route_direction_id = rd.network_route_direction_id
+           ORDER BY rsp.network_route_stop_point_order DESC LIMIT 1
        ) AS end_scheduled_stop_point_transmodel_id,
        rd.network_route_direction_valid_date_range AS valid_date_range
     FROM network.network_routes r


### PR DESCRIPTION
- Set chunk size to 1 if step imports data to Jore 4 database. This is a
  compromise which decreases the performance of the import job but it also
  provides us an easy to ignore rows which have errors and ensure that all
  the other rows are inserted into the target table.
- Write error messages caused by ignored rows to the log.
- Fix a bug found from the join condition of a SQL query which reads
  imported routes from the importer's database.
- Ensure that jOOQ APi isn't called if the list of imported
  rows is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/65)
<!-- Reviewable:end -->
