### PR TITLE
Fix the error handling of journey pattern jore4 import

### DIFF
--- a/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
+++ b/src/main/java/fi/hsl/jore/importer/config/jobs/JobConfig.java
@@ -603,10 +603,12 @@ public class JobConfig extends BatchConfig {
                                           final JourneyPatternExportWriter writer) {
         return steps.get("exportJourneyPatternsStep")
                 .allowStartIfComplete(true)
-                .<ExportableJourneyPattern, TransmodelJourneyPattern>chunk(1000)
+                .<ExportableJourneyPattern, TransmodelJourneyPattern>chunk(1)
                 .reader(reader.build())
                 .processor(processor)
                 .writer(writer)
+                .faultTolerant()
+                .skipPolicy(new AlwaysSkipItemSkipPolicy())
                 .build();
     }
 }

--- a/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelJourneyPatternRepository.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/transmodel/repository/TransmodelJourneyPatternRepository.java
@@ -24,19 +24,18 @@ public class TransmodelJourneyPatternRepository implements ITransmodelJourneyPat
 
     @Override
     public void insert(final List<? extends TransmodelJourneyPattern> journeyPatterns) {
-        final BatchBindStep batch = db.batch(db.insertInto(
-                JOURNEY_PATTERN_,
-                JOURNEY_PATTERN_.JOURNEY_PATTERN_ID,
-                JOURNEY_PATTERN_.ON_ROUTE_ID
-        )
-                        .values((UUID) null, null)
-        );
+        if (!journeyPatterns.isEmpty()) {
+            final BatchBindStep batch = db.batch(db.insertInto(JOURNEY_PATTERN_,
+                            JOURNEY_PATTERN_.JOURNEY_PATTERN_ID,
+                            JOURNEY_PATTERN_.ON_ROUTE_ID
+            ).values((UUID) null, null));
 
-        journeyPatterns.forEach(journeyPattern -> batch.bind(
-                journeyPattern.journeyPatternId(),
-                journeyPattern.routeId()
-        ));
+            journeyPatterns.forEach(journeyPattern -> batch.bind(
+                    journeyPattern.journeyPatternId(),
+                    journeyPattern.routeId()
+            ));
 
-        batch.execute();
+            batch.execute();
+        }
     }
 }


### PR DESCRIPTION
This commit ensures that the step which imports journey patterns
to Jore 4 database uses the same error handling as other steps
which import data to Jore 4 database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/66)
<!-- Reviewable:end -->
