### PR TITLE
Replace duplicate stop points with stop point found from Digiroad data

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -31,6 +31,9 @@ services:
     networks:
       - jore4
 
+  jore4-mapmatching:
+    image: "hsldevcom/jore4-map-matching:main--20220511-b2e45b67b95ac7962fad518856450c62ed9e3b01"
+
   jore4-mssqltestdb:
     # pin compatible version of mssql schema
     image: "hsldevcom/jore4-mssql-testdb:schema-only-main--21ef30b56e38b0cfa118ccf610ba0fa7e9e00ef7"

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/line/LineExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/line/LineExportProcessor.java
@@ -4,6 +4,8 @@ import fi.hsl.jore.importer.feature.network.line.dto.ExportableLine;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelLine;
 import fi.hsl.jore.importer.feature.transmodel.entity.VehicleMode;
 import fi.hsl.jore.importer.feature.transmodel.util.ValidityPeriodUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +18,14 @@ import java.util.UUID;
 @Component
 public class LineExportProcessor implements ItemProcessor<ExportableLine, TransmodelLine> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(LineExportProcessor.class);
+
     private static final int DEFAULT_PRIORITY = 10;
 
     @Override
     public TransmodelLine process(final ExportableLine input) throws Exception {
+        LOGGER.debug("Processing line: {}", input);
+
         return TransmodelLine.of(
                 UUID.randomUUID(),
                 input.externalId().value(),

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternExportProcessor.java
@@ -2,6 +2,8 @@ package fi.hsl.jore.importer.feature.batch.route;
 
 import fi.hsl.jore.importer.feature.network.route.dto.ExportableJourneyPattern;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelJourneyPattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -14,8 +16,12 @@ import java.util.UUID;
 @Component
 public class JourneyPatternExportProcessor implements ItemProcessor<ExportableJourneyPattern, TransmodelJourneyPattern> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JourneyPatternExportProcessor.class);
+
     @Override
     public TransmodelJourneyPattern process(final ExportableJourneyPattern input) throws Exception {
+        LOGGER.debug("Processing journey pattern: {}", input);
+
         return TransmodelJourneyPattern.of(
                 UUID.randomUUID(),
                 input.routeDirectionId(),

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternStopExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternStopExportProcessor.java
@@ -2,6 +2,8 @@ package fi.hsl.jore.importer.feature.batch.route;
 
 import fi.hsl.jore.importer.feature.network.route.dto.ExportableJourneyPatternStop;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelJourneyPatternStop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -12,8 +14,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class JourneyPatternStopExportProcessor implements ItemProcessor<ExportableJourneyPatternStop, TransmodelJourneyPatternStop> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JourneyPatternStopExportProcessor.class);
+
     @Override
     public TransmodelJourneyPatternStop process(final ExportableJourneyPatternStop input) throws Exception {
+        LOGGER.debug("Processing journey pattern stop: {}", input);
+
         return TransmodelJourneyPatternStop.of(
                 input.isHastusPoint(),
                 input.isViaPoint(),

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/route/MapMatchingProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/route/MapMatchingProcessor.java
@@ -39,6 +39,11 @@ public class MapMatchingProcessor implements ItemProcessor<ExportableRouteGeomet
 
     @Override
     public TransmodelRouteGeometry process(final ExportableRouteGeometry routeGeometryInput) throws Exception {
+        LOGGER.debug("Processing route geometry with routeDirectionId: {} and routeDirectionExtId: {}",
+                routeGeometryInput.routeDirectionId(),
+                routeGeometryInput.routeDirectionExtId()
+        );
+
         final List<ExportableRoutePoint> routePointsInput = routePointRepository.findExportableRoutePointsByRouteDirectionId(routeGeometryInput.routeDirectionId());
         if (routePointsInput.isEmpty()) {
             LOGGER.error(

--- a/src/main/java/fi/hsl/jore/importer/feature/batch/route/RouteExportProcessor.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/batch/route/RouteExportProcessor.java
@@ -4,6 +4,8 @@ import fi.hsl.jore.importer.feature.network.route.dto.ExportableRoute;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelRoute;
 import fi.hsl.jore.importer.feature.transmodel.entity.TransmodelRouteDirection;
 import fi.hsl.jore.importer.feature.transmodel.util.ValidityPeriodUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +18,14 @@ import java.util.UUID;
 @Component
 public class RouteExportProcessor implements ItemProcessor<ExportableRoute, TransmodelRoute> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RouteExportProcessor.class);
+
     private static final int DEFAULT_PRIORITY = 10;
 
     @Override
     public TransmodelRoute process(final ExportableRoute input) throws Exception {
+        LOGGER.debug("Processing route: {}", input);
+
         return TransmodelRoute.of(
                 UUID.randomUUID(),
                 input.name(),

--- a/src/main/java/fi/hsl/jore/importer/feature/mapmatching/dto/request/MapMatchingRequestBuilder.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/mapmatching/dto/request/MapMatchingRequestBuilder.java
@@ -60,11 +60,17 @@ public class MapMatchingRequestBuilder {
             if (input.type() == NodeType.STOP) {
                 routePoint.setNationalId(input.stopPointElyNumber().orElse(null));
                 routePoint.setPassengerId(input.stopPointShortId().orElseThrow(
-                        () -> new NullPointerException("passengerId cannot be null when route point is stop point")
+                        () -> new NullPointerException(String.format(
+                                "Cannot create map matching request. passengerId is null and the route point is stop point with national id: %d",
+                                routePoint.getNationalId()
+                        ))
                 ));
 
                 final Point projectedLocation = toGeoJson(input.projectedLocation().orElseThrow(
-                        () -> new NullPointerException("projectedLocation cannot be null when route point is stop point")
+                        () -> new NullPointerException(String.format(
+                                "Cannot create map matching request. projectedLocation is null and the route point is stop point with national id: %d",
+                                routePoint.getNationalId()
+                        ))
                 ));
                 routePoint.setProjectedLocation(projectedLocation);
             }

--- a/src/main/java/fi/hsl/jore/importer/feature/network/scheduled_stop_point/dto/ExportableScheduledStopPoint.java
+++ b/src/main/java/fi/hsl/jore/importer/feature/network/scheduled_stop_point/dto/ExportableScheduledStopPoint.java
@@ -2,6 +2,7 @@ package fi.hsl.jore.importer.feature.network.scheduled_stop_point.dto;
 
 import fi.hsl.jore.importer.feature.common.dto.field.MultilingualString;
 import fi.hsl.jore.importer.feature.common.dto.field.generated.ExternalId;
+import io.vavr.collection.List;
 import org.immutables.value.Value;
 import org.locationtech.jts.geom.Point;
 
@@ -13,18 +14,38 @@ import java.util.Optional;
  * Jore 4 transmodel schema.
  */
 @Value.Immutable
-public interface ExportableScheduledStopPoint extends CommonFields<ExportableScheduledStopPoint> {
+public interface ExportableScheduledStopPoint {
+
+    /**
+     * Exported scheduled stop points have multiple ely numbers and external ids
+     * because the Jore 3 database can contain multiple instances of the same stop.
+     * When we transfer this information to the Jore 4 database, importer must filter
+     * duplicate rows and ensure that only one stop is inserted into the Jore 4 datababase.
+     *
+     * These lists (elyNumbers and externalIds) contain ely number and external id pairs
+     * (list items which have the same index number are a pair) which refer to a single
+     * row found from the Jore 4 database. When the importer processes exported scheduled
+     * stop points, it exports the scheduled stop point which is found from the Digiroad
+     * data and inserts its ely number and external id into the Jore 4 database.
+     */
+    List<Long> elyNumbers();
+
+    List<ExternalId> externalIds();
 
     Point location();
 
-    static ImmutableExportableScheduledStopPoint of(final ExternalId externalId,
-                                                    final Optional<Long> elynumber,
+    MultilingualString name();
+
+    Optional<String> shortId();
+
+    static ImmutableExportableScheduledStopPoint of(final List<ExternalId> externalIds,
+                                                    final List<Long> elynumbers,
                                                     final Point location,
                                                     final MultilingualString name,
                                                     final Optional<String> shortId) {
         return ImmutableExportableScheduledStopPoint.builder()
-                .externalId(externalId)
-                .elyNumber(elynumber)
+                .externalIds(externalIds)
+                .elyNumbers(elynumbers)
                 .location(location)
                 .name(name)
                 .shortId(shortId)

--- a/src/main/resources/export/export_lines.sql
+++ b/src/main/resources/export/export_lines.sql
@@ -6,4 +6,5 @@ SELECT
         lh.network_line_header_name_short AS short_name,
         lh.network_line_header_valid_date_range AS valid_date_range
 FROM network.network_lines l
-JOIN network.network_line_headers lh ON (lh.network_line_id = l.network_line_id);
+JOIN network.network_line_headers lh ON (lh.network_line_id = l.network_line_id)
+ORDER BY lh.network_line_header_valid_date_range DESC;

--- a/src/main/resources/export/export_route_geometries.sql
+++ b/src/main/resources/export/export_route_geometries.sql
@@ -15,4 +15,5 @@ CROSS JOIN LATERAL (
             rd.network_route_direction_id = rdo.network_route_direction_id AND l.infrastructure_network_type = 'road'
         ORDER BY rl.network_route_link_order
     ) links ) network_route_direction_shape
-WHERE network_route_direction_shape IS NOT NULL AND rdo.network_route_transmodel_id IS NOT NULL;
+WHERE network_route_direction_shape IS NOT NULL AND rdo.network_route_transmodel_id IS NOT NULL
+ORDER BY rdo.network_route_direction_valid_date_range DESC;

--- a/src/main/resources/export/export_routes.sql
+++ b/src/main/resources/export/export_routes.sql
@@ -4,38 +4,39 @@ SELECT r.network_route_name AS name,
        rd.network_route_direction_type AS direction_type,
        l.network_line_transmodel_id AS line_transmodel_id,
        /*
-            Finds the first scheduled stop point of the exported route. Note that we must use
-            the split_part() function when we join the network.scheduled_stop_points and
-            network.network_route_stop_points tables because the value of the network_route_stop_point_ext_id
-            column of the network.network_route_stop_points table uses this format:
-
-            [the id of the route link]-[the external id of the scheduled stop point].
+            Finds the first scheduled stop point of the exported route.
         */
        (
-           SELECT ssp.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points ssp
-           JOIN network.network_route_stop_points rsp ON (split_part(rsp.network_route_stop_point_ext_id, '-', 2) = ssp.scheduled_stop_point_ext_id)
-           JOIN network.network_route_points rp ON (rp.network_route_point_id = rsp.network_route_point_id)
-           JOIN network.network_route_directions rd1 ON (rd1.network_route_direction_id = rp.network_route_direction_id)
-           WHERE rd1.network_route_id = r.network_route_id AND rd1.network_route_direction_id = rd.network_route_direction_id
-           ORDER BY rsp.network_route_stop_point_order ASC LIMIT 1
+            SELECT sq1.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points sq1
+            WHERE sq1.scheduled_stop_point_short_id = (
+                SELECT ssp.scheduled_stop_point_short_id FROM network.scheduled_stop_points ssp
+                JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = ssp.infrastructure_node_id)
+                JOIN network.network_route_points rp ON (rp.infrastructure_node = n.infrastructure_node_id)
+                JOIN network.network_route_stop_points rsp ON (rp.network_route_point_id = rsp.network_route_point_id)
+                JOIN network.network_route_directions rd1 ON (rd1.network_route_direction_id = rp.network_route_direction_id)
+                WHERE rd1.network_route_direction_id = rd.network_route_direction_id
+                ORDER BY rsp.network_route_stop_point_order ASC LIMIT 1
+            )
+            AND sq1.scheduled_stop_point_transmodel_id IS NOT NULL
        ) AS start_scheduled_stop_point_transmodel_id,
        /*
-            Finds the last scheduled stop point of the exported route. Note that we must use
-            the split_part() function when we join the network.scheduled_stop_points and
-            network.network_route_stop_points tables because the value of the network_route_stop_point_ext_id
-            column of the network.network_route_stop_points table uses this format:
-
-            [the id of the route link]-[the external id of the scheduled stop point].
+            Finds the last scheduled stop point of the exported route.
         */
        (
-           SELECT ssp.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points ssp
-           JOIN network.network_route_stop_points rsp ON (split_part(rsp.network_route_stop_point_ext_id, '-', 2) = ssp.scheduled_stop_point_ext_id)
-           JOIN network.network_route_points rp ON (rp.network_route_point_id = rsp.network_route_point_id)
-           JOIN network.network_route_directions rd2 ON (rd2.network_route_direction_id = rp.network_route_direction_id)
-           WHERE rd2.network_route_id = r.network_route_id AND rd2.network_route_direction_id = rd.network_route_direction_id
-           ORDER BY rsp.network_route_stop_point_order DESC LIMIT 1
+            SELECT sq1.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points sq1
+            WHERE sq1.scheduled_stop_point_short_id = (
+                SELECT ssp.scheduled_stop_point_short_id FROM network.scheduled_stop_points ssp
+                JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = ssp.infrastructure_node_id)
+                JOIN network.network_route_points rp ON (rp.infrastructure_node = n.infrastructure_node_id)
+                JOIN network.network_route_stop_points rsp ON (rp.network_route_point_id = rsp.network_route_point_id)
+                JOIN network.network_route_directions rd2 ON (rd2.network_route_direction_id = rp.network_route_direction_id)
+                WHERE rd2.network_route_direction_id = rd.network_route_direction_id
+                ORDER BY rsp.network_route_stop_point_order DESC LIMIT 1
+            )
+            AND sq1.scheduled_stop_point_transmodel_id IS NOT NULL
        ) AS end_scheduled_stop_point_transmodel_id,
        rd.network_route_direction_valid_date_range AS valid_date_range
     FROM network.network_routes r
     JOIN network.network_route_directions rd ON (rd.network_route_id = r.network_route_id)
     JOIN network.network_lines l ON (l.network_line_id = r.network_line_id)
+    ORDER BY rd.network_route_direction_valid_date_range DESC;

--- a/src/main/resources/export/export_scheduled_stop_points.sql
+++ b/src/main/resources/export/export_scheduled_stop_points.sql
@@ -1,13 +1,20 @@
-SELECT s.scheduled_stop_point_ext_id AS external_id,
-       s.scheduled_stop_point_ely_number AS ely_number,
+SELECT (
+           SELECT string_agg(sq1.scheduled_stop_point_ext_id, ',') FROM network.scheduled_stop_points sq1
+           WHERE sq1.scheduled_stop_point_short_id = s.scheduled_stop_point_short_id
+       ) AS external_id,
+       (
+           SELECT string_agg(sq1.scheduled_stop_point_ely_number::text, ',') FROM network.scheduled_stop_points sq1
+           WHERE sq1.scheduled_stop_point_short_id = s.scheduled_stop_point_short_id
+       ) AS ely_number,
        n.infrastructure_node_location AS location,
        s.scheduled_stop_point_name AS name,
        s.scheduled_stop_point_short_id AS short_id
 FROM network.scheduled_stop_points s
-    JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = s.infrastructure_node_id)
+         JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = s.infrastructure_node_id)
 WHERE s.scheduled_stop_point_ely_number IS NOT NULL
-AND s.scheduled_stop_point_ext_id=(
+  AND LENGTH(s.scheduled_stop_point_short_id) > 4
+  AND s.scheduled_stop_point_ext_id=(
     SELECT MIN(sp.scheduled_stop_point_ext_id)
     FROM network.scheduled_stop_points sp
-    where sp.scheduled_stop_point_short_id=s.scheduled_stop_point_short_id
+    WHERE sp.scheduled_stop_point_short_id=s.scheduled_stop_point_short_id
 )

--- a/src/main/resources/export/export_stops_of_journey_patterns.sql
+++ b/src/main/resources/export/export_stops_of_journey_patterns.sql
@@ -2,18 +2,16 @@ SELECT rd.journey_pattern_transmodel_id AS journey_pattern_transmodel_id,
        rsp.network_route_stop_point_hastus_point AS is_hastus_point,
        rsp.network_route_stop_point_via_point AS is_via_point,
        rsp.network_route_stop_point_order AS order_number,
-       ssp.scheduled_stop_point_transmodel_id AS scheduled_stop_point_transmodel_id
+       (
+            SELECT sq1.scheduled_stop_point_transmodel_id FROM network.scheduled_stop_points sq1
+            WHERE sq1.scheduled_stop_point_short_id = ssp.scheduled_stop_point_short_id
+            AND sq1.scheduled_stop_point_transmodel_id IS NOT NULL
+       ) AS scheduled_stop_point_transmodel_id
 FROM network.network_route_directions rd
-JOIN network.network_route_points rp ON (rp.network_route_direction_id = rd.network_route_direction_id)
-JOIN network.network_route_stop_points rsp ON (rsp.network_route_point_id = rp.network_route_point_id)
-/*
-    We must use the split_part() function when we join the network.scheduled_stop_points and
-    network.network_route_stop_points tables because the value of the network_route_stop_point_ext_id
-    column of the network.network_route_stop_points table uses this format:
-
-    [the id of the route link]-[the external id of the scheduled stop point].
-*/
-JOIN network.scheduled_stop_points ssp ON (ssp.scheduled_stop_point_ext_id = split_part(rsp.network_route_stop_point_ext_id, '-', 2))
+         JOIN network.network_route_points rp ON (rp.network_route_direction_id = rd.network_route_direction_id)
+         JOIN infrastructure_network.infrastructure_nodes n ON (n.infrastructure_node_id = rp.infrastructure_node)
+         JOIN network.network_route_stop_points rsp ON (rsp.network_route_point_id = rp.network_route_point_id)
+         JOIN network.scheduled_stop_points ssp ON (ssp.infrastructure_node_id = n.infrastructure_node_id)
 WHERE rd.journey_pattern_transmodel_id IS NOT NULL
-AND ssp.scheduled_stop_point_transmodel_id IS NOT NULL
+  AND ssp.scheduled_stop_point_transmodel_id IS NOT NULL
 ORDER BY rsp.network_route_stop_point_order ASC;

--- a/src/test/resources/sql/destination/populate_scheduled_stop_points_with_same_short_id.sql
+++ b/src/test/resources/sql/destination/populate_scheduled_stop_points_with_same_short_id.sql
@@ -1,0 +1,25 @@
+INSERT INTO network.scheduled_stop_points (
+    scheduled_stop_point_id,
+    scheduled_stop_point_ext_id,
+    infrastructure_node_id,
+    scheduled_stop_point_ely_number,
+    scheduled_stop_point_name,
+    scheduled_stop_point_short_id
+)
+VALUES
+    (
+        '058a63b3-365b-4676-af51-809bef577cdd',
+        'c',
+        'cc11a5db-2ae7-4220-adfe-aca5d6620909',
+        1234567890,
+        '{"fi_FI": "Yliopisto vanha","sv_SE": "Universitetet gamla"}',
+        'H1234'
+    ),
+    (
+        'c5390e54-1135-4b85-aab9-cf4a51c559bd',
+        'd',
+        'cc11a5db-2ae7-4220-adfe-aca5d6620909',
+        9876543211,
+        '{"fi_FI": "Yliopisto vanha","sv_SE": "Universitetet gamla"}',
+        'H1234'
+    );


### PR DESCRIPTION
Jore 3 database can contain duplicate stop points which should be combined into
one stop point when this data is imported to the Jore 4 database. This commit
implements this feature by making the following changes to the codebase:

- Select all possible ely number and external id pairs from the importers database.
- Iterate all ely numbers one by one and import the information of a stop point
  whose information is found from Digiroad.
- Ensure that deleted stop points are ignored when we import route geometries
  to the Jore 4 database.
- Ensure that importer can select the imported stop point (in case of duplicates)
  when it imports routes and scheduled stop points of journey patterns to the
  Jore 4 database.
- Order imported lines, routes, and route geometries in descending order
  by using the valid date range column as a sort column.
- Improve test coverage.
- Improve logging.

Resolves /HSLdevcom/jore4/issues/762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/84)
<!-- Reviewable:end -->
