### PR TITLE
Script for easy importing of jore3 database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ docker/*
 
 #digiroad stops csv file
 digiroad_stops*.csv
+
+#possible jore3 backup file
+jore3dump/*
+!jore3dump/put-bak-file-here.txt

--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ If you want to use this option, you have to follow these steps:
 
 If you want to create a package that can be used for deployment, you have run the command: `mvn clean package spring-boot:repackage -P prod`
 
+### Restoring a Jore 3 Database Dump to the testing Database
+
+If you want to restore a database dump from Jore 3 to the testing database, there is a script provided for it. Put the jore3 .bak file to the `jore3dump` directory and run `./apply-jore3-database-backup.sh jore3dump.bak`, where `jore3dump.bak` should be replaced with the name of the .bak file you want to apply.
+
 ### Taking a Database Dump From the Jore 4 Database
 
 When you want to take a database dump from the Jore 4 database, you can use one of these two options:

--- a/apply-jore3-database-backup.sh
+++ b/apply-jore3-database-backup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ -z ${1} ]]; then
+  echo "Usage: ${0} FILE.bak"
+  echo "Applies the given .bak file to the running jore3testdb."
+  echo "Where FILE.bak is a .bak in jore3dump directory, while which contains the relevant database dump."
+  echo "User needs to supply SA user password when restoring the backup."
+  exit 1
+fi
+
+docker exec -it mssqltestdb /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -Q "RESTORE DATABASE [jore3testdb] FROM DISK = N'/mnt/jore3dump/${1}' WITH FILE = 1, NOUNLOAD, REPLACE, RECOVERY, STATS = 5"

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -37,6 +37,9 @@ services:
   jore4-mssqltestdb:
     # pin compatible version of mssql schema
     image: "hsldevcom/jore4-mssql-testdb:schema-only-jr_linja_vaatimus-table--20220523-1854abfa889ee6432878c5203a115ad4945506d3"
+    # volume to easily use jore3 database dump
+    volumes:
+      - ../jore3dump:/mnt/jore3dump
 
   jore4-hasura:
     # pin compatible version of jore4 data model

--- a/jore3dump/put-bak-file-here.txt
+++ b/jore3dump/put-bak-file-here.txt
@@ -1,0 +1,1 @@
+Add jore3 dump file here to use it in testing database


### PR DESCRIPTION
A mssql database dump .bak file can be deposited in the jore3dump directory and applied to the jore3 test database using the apply-jore3-database-backup.sh script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/95)
<!-- Reviewable:end -->
