### PR TITLE
Pin the latest version of map-matching service

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -32,7 +32,7 @@ services:
       - jore4
 
   jore4-mapmatching:
-    image: "hsldevcom/jore4-map-matching:main--20220511-b2e45b67b95ac7962fad518856450c62ed9e3b01"
+    image: "hsldevcom/jore4-map-matching:main--20221101-55b0d65292b29db99c9ddaa93de6b422326d2976"
 
   jore4-mssqltestdb:
     # pin compatible version of mssql schema


### PR DESCRIPTION
Pin the latest version of map-matching service to add support for routes going via closed-loop road links.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-jore3-importer/99)
<!-- Reviewable:end -->
