### PR TITLE
Change docker-compose project name to lowercase because of more strict rules

### DIFF
--- a/development.sh
+++ b/development.sh
@@ -8,7 +8,7 @@ COMMAND=${1:-}
 
 # Define a Docker Compose project name to distinguish
 # the docker environment of this project from others
-export COMPOSE_PROJECT_NAME=JOREIMPORTER
+export COMPOSE_PROJECT_NAME=jore3-importer
 
 DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.testdb-volume.yml -f ./docker/docker-compose.custom.yml"
 


### PR DESCRIPTION
docker-compose v2.17.0 (2023-03-23) enforces more strict rules with regard to project name validation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/113)
<!-- Reviewable:end -->
