### PR TITLE
Switch to Temurin JRE v17

### DIFF
--- a/.github/workflows/generate-jooq.yml
+++ b/.github/workflows/generate-jooq.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           custom_docker_compose: ./docker/docker-compose.custom.yml
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           java-package: jdk
           architecture: x64
           distribution: temurin

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           custom_docker_compose: ./docker/docker-compose.custom.yml
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           java-package: jdk
           architecture: x64
           distribution: temurin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder docker image
-FROM maven:3-openjdk-11 AS builder
+FROM maven:3-eclipse-temurin-17 AS builder
 
 # set up workdir
 WORKDIR /build
@@ -14,7 +14,7 @@ COPY ./profiles/prod /build/profiles/prod
 RUN mvn clean package spring-boot:repackage -Pprod
 
 # distributed docker image
-FROM openjdk:11-jre
+FROM eclipse-temurin:17.0.7_7-jre
 
 # expose server port
 EXPOSE 8080


### PR DESCRIPTION
Standardise on Adoptium Temurin Eclipse OpenJDK. This is the same as what is used in `jore4-map-matching` and `jore4-hastus`.

Update JRE from 11 (LTS) to 17 (LTS) to enabe migration to Spring Boot 3 in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/121)
<!-- Reviewable:end -->
