### PR TITLE
Filter out legacy lines to avoid db uniqueness constraint violations

### DIFF
--- a/src/main/resources/jore4-export/export_lines.sql
+++ b/src/main/resources/jore4-export/export_lines.sql
@@ -1,12 +1,23 @@
+-- Since few years ago the last three digits of the line number were not
+-- unique, and since in Jore4 the line number uses only those last three digits
+-- (stripping the preceding digit for the legacy municipality code), the lines
+-- of the 'LEGACY_NOT_USED' legacy municipality code are filtered out to avoid
+-- uniqueness constraint problems in Jore4 database.
+
+-- Currently, only bus and ferry lines are exported to Jore4.
+
 SELECT
-        l.network_line_ext_id AS external_id,
-        l.network_line_number AS line_number,
-        l.infrastructure_network_type AS network_type,
-        l.network_line_type_of_line AS type_of_line,
-        l.network_line_legacy_hsl_municipality_code AS legacy_hsl_municipality_code,
-        lh.network_line_header_name AS name,
-        lh.network_line_header_name_short AS short_name,
-        lh.network_line_header_valid_date_range AS valid_date_range
+    l.network_line_ext_id AS external_id,
+    l.network_line_number AS line_number,
+    l.infrastructure_network_type AS network_type,
+    l.network_line_type_of_line AS type_of_line,
+    l.network_line_legacy_hsl_municipality_code AS legacy_hsl_municipality_code,
+    lh.network_line_header_name AS name,
+    lh.network_line_header_name_short AS short_name,
+    lh.network_line_header_valid_date_range AS valid_date_range
 FROM network.network_lines l
-JOIN network.network_line_headers lh ON (lh.network_line_id = l.network_line_id)
+JOIN network.network_line_headers lh USING (network_line_id)
+WHERE
+    l.infrastructure_network_type IN ('road', 'waterway')
+    AND l.network_line_legacy_hsl_municipality_code NOT IN ('LEGACY_NOT_USED', 'TESTING_NOT_USED')
 ORDER BY lh.network_line_header_valid_date_range DESC;

--- a/src/main/resources/jore4-export/export_routes.sql
+++ b/src/main/resources/jore4-export/export_routes.sql
@@ -10,5 +10,5 @@ SELECT
 FROM network.network_routes r
 JOIN network.network_route_directions rd USING (network_route_id)
 JOIN network.network_lines l USING (network_line_id)
-WHERE NOT isempty(rd.network_route_direction_valid_date_range * '[2021-01-01, 2050-01-01)'::daterange)
-ORDER BY rd.network_route_direction_valid_date_range DESC
+WHERE rd.network_route_direction_valid_date_range && '[2021-01-01, 2050-01-01)'::daterange
+ORDER BY rd.network_route_direction_valid_date_range DESC;

--- a/src/main/resources/jore4-export/export_routes.sql
+++ b/src/main/resources/jore4-export/export_routes.sql
@@ -1,3 +1,12 @@
+-- Since few years ago the last three digits of the line/route number were not
+-- unique, and since in Jore4 the line/route number uses only those last three
+-- digits (stripping the preceding digit for the legacy municipality code), the
+-- lines of the 'LEGACY_NOT_USED' legacy municipality code are filtered out to
+-- avoid uniqueness constraint problems in Jore4 database.
+
+-- Currently, only bus and ferry routes are exported to Jore4. Also, we only take
+-- routes that are valid on or after 1.1.2021.
+
 SELECT
     r.network_route_number AS route_number,
     r.network_route_hidden_variant AS hidden_variant,
@@ -10,5 +19,8 @@ SELECT
 FROM network.network_routes r
 JOIN network.network_route_directions rd USING (network_route_id)
 JOIN network.network_lines l USING (network_line_id)
-WHERE rd.network_route_direction_valid_date_range && '[2021-01-01, 2050-01-01)'::daterange
+WHERE
+    l.infrastructure_network_type IN ('road', 'waterway')
+    AND l.network_line_legacy_hsl_municipality_code NOT IN ('LEGACY_NOT_USED', 'TESTING_NOT_USED')
+    AND rd.network_route_direction_valid_date_range && '[2021-01-01, 2050-01-01)'::daterange
 ORDER BY rd.network_route_direction_valid_date_range DESC;

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ExportJourneyPatternStopsStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ExportJourneyPatternStopsStepTest.java
@@ -27,7 +27,7 @@ import static org.assertj.db.api.Assertions.assertThat;
 @Sql(scripts = {
         "/sql/importer/drop_tables.sql",
         "/sql/importer/populate_infrastructure_nodes.sql",
-        "/sql/importer/populate_lines_with_jore4_ids.sql",
+        "/sql/importer/populate_lines.sql",
         "/sql/importer/populate_routes.sql",
         "/sql/importer/populate_route_directions_with_journey_pattern_jore4_ids.sql",
         "/sql/importer/populate_route_points_for_jore4_export.sql",

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ExportJourneyPatternsStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ExportJourneyPatternsStepTest.java
@@ -20,7 +20,7 @@ import static org.assertj.db.api.Assertions.assertThat;
 @Sql(scripts = {
         "/sql/importer/drop_tables.sql",
         "/sql/importer/populate_infrastructure_nodes.sql",
-        "/sql/importer/populate_lines_with_jore4_ids.sql",
+        "/sql/importer/populate_lines.sql",
         "/sql/importer/populate_routes.sql",
         "/sql/importer/populate_route_directions_with_jore4_ids.sql"
 })

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ExportLineStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ExportLineStepTest.java
@@ -43,7 +43,7 @@ class ExportLineStepTest extends BatchIntegrationTest {
     private static final String EXPECTED_NAME = "{\"fi_FI\":\"Eira - Töölö - Sörnäinen (M) - Käpylä\",\"sv_SE\":\"Eira - Tölö - Sörnäs (M) - Kottby\"}";
     private static final String EXPECTED_SHORT_NAME = "{\"fi_FI\":\"Eira-Töölö-Käpylä\",\"sv_SE\":\"Eira-Tölö-Kottby\"}";
 
-    private static final VehicleMode EXPECTED_PRIMARY_VEHICLE_MODE = VehicleMode.TRAM;
+    private static final VehicleMode EXPECTED_PRIMARY_VEHICLE_MODE = VehicleMode.BUS;
     private static final int EXPECTED_PRIORITY = 10;
     private static final LegacyHslMunicipalityCode EXPECTED_LEGACY_HSL_MUNICIPALITY_CODE = LegacyHslMunicipalityCode.HELSINKI;
 

--- a/src/test/java/fi/hsl/jore/importer/config/jobs/ExportRouteGeometriesStepTest.java
+++ b/src/test/java/fi/hsl/jore/importer/config/jobs/ExportRouteGeometriesStepTest.java
@@ -23,7 +23,7 @@ import static org.assertj.db.api.Assertions.assertThat;
         "/sql/importer/populate_infrastructure_nodes.sql",
         "/sql/importer/populate_infrastructure_links.sql",
         "/sql/importer/populate_infrastructure_link_shapes.sql",
-        "/sql/importer/populate_lines_with_jore4_ids.sql",
+        "/sql/importer/populate_lines.sql",
         "/sql/importer/populate_routes.sql",
         "/sql/importer/populate_route_directions_with_jore4_ids.sql",
         "/sql/importer/populate_route_links.sql",

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/line/LineExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/line/LineExportReaderTest.java
@@ -36,8 +36,8 @@ class LineExportReaderTest {
     private static final String EXPECTED_SWEDISH_NAME = "Eira - Tölö - Sörnäs (M) - Kottby";
     private static final String EXPECTED_SWEDISH_SHORT_NAME = "Eira-Tölö-Kottby";
 
-    private static final NetworkType EXPECTED_NETWORK_TYPE = NetworkType.TRAM_TRACK;
-    private static final TypeOfLine EXPECTED_TYPE_OF_LINE = TypeOfLine.CITY_TRAM_SERVICE;
+    private static final NetworkType EXPECTED_NETWORK_TYPE = NetworkType.ROAD;
+    private static final TypeOfLine EXPECTED_TYPE_OF_LINE = TypeOfLine.STOPPING_BUS_SERVICE;
     private static final LegacyHslMunicipalityCode EXPECTED_LEGACY_HSL_MUNICIPALITY_CODE = LegacyHslMunicipalityCode.HELSINKI;
 
     private static final LocalDate EXPECTED_VALID_DATE_RANGE_START = LocalDate.of(2021, 10, 4);

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternExportReaderTest.java
@@ -57,7 +57,7 @@ class JourneyPatternExportReaderTest {
     @Sql(scripts = {
             "/sql/importer/drop_tables.sql",
             "/sql/importer/populate_infrastructure_nodes.sql",
-            "/sql/importer/populate_lines_with_jore4_ids.sql",
+            "/sql/importer/populate_lines.sql",
             "/sql/importer/populate_routes.sql",
             "/sql/importer/populate_route_directions_with_jore4_ids.sql"
     })

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternStopExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/route/JourneyPatternStopExportReaderTest.java
@@ -59,7 +59,7 @@ class JourneyPatternStopExportReaderTest {
     @Sql(scripts = {
             "/sql/importer/drop_tables.sql",
             "/sql/importer/populate_infrastructure_nodes.sql",
-            "/sql/importer/populate_lines_with_jore4_ids.sql",
+            "/sql/importer/populate_lines.sql",
             "/sql/importer/populate_routes.sql",
             "/sql/importer/populate_route_directions_with_journey_pattern_jore4_ids.sql",
             "/sql/importer/populate_route_points_for_jore4_export.sql",

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/route/RouteExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/route/RouteExportReaderTest.java
@@ -28,10 +28,10 @@ class RouteExportReaderTest {
 
     private final JdbcCursorItemReader<ImporterRoute> reader;
 
-   @Autowired
-   RouteExportReaderTest(RouteExportReader reader) {
-       this.reader = reader.build();
-   }
+    @Autowired
+    RouteExportReaderTest(final RouteExportReader reader) {
+        this.reader = reader.build();
+    }
 
     @BeforeEach
     void openReader() {

--- a/src/test/java/fi/hsl/jore/importer/feature/batch/route/RouteGeometryExportReaderTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/batch/route/RouteGeometryExportReaderTest.java
@@ -58,7 +58,7 @@ public class RouteGeometryExportReaderTest {
     @Sql(scripts = {
             "/sql/importer/drop_tables.sql",
             "/sql/importer/populate_infrastructure_nodes.sql",
-            "/sql/importer/populate_lines_with_jore4_ids.sql",
+            "/sql/importer/populate_lines.sql",
             "/sql/importer/populate_routes.sql",
             "/sql/importer/populate_route_directions_with_jore4_ids.sql",
             "/sql/importer/populate_route_points_for_jore4_export.sql",

--- a/src/test/java/fi/hsl/jore/importer/feature/network/route_point/repository/RoutePointExportRepositoryTest.java
+++ b/src/test/java/fi/hsl/jore/importer/feature/network/route_point/repository/RoutePointExportRepositoryTest.java
@@ -52,7 +52,7 @@ class RoutePointExportRepositoryTest {
         @Sql(scripts = {
                 "/sql/importer/drop_tables.sql",
                 "/sql/importer/populate_infrastructure_nodes.sql",
-                "/sql/importer/populate_lines_with_jore4_ids.sql",
+                "/sql/importer/populate_lines.sql",
                 "/sql/importer/populate_routes.sql",
                 "/sql/importer/populate_route_directions_with_journey_pattern_jore4_ids.sql",
                 "/sql/importer/populate_route_points_for_jore4_export.sql",

--- a/src/test/resources/sql/importer/populate_lines.sql
+++ b/src/test/resources/sql/importer/populate_lines.sql
@@ -10,7 +10,7 @@ VALUES (
         '579db108-1f52-4364-9815-5f17c84ce3fb',
         '1001',
         '1',
-        'tram_track',
-        'city_tram_service',
+        'road',
+        'stopping_bus_service',
         'HELSINKI'
 );

--- a/src/test/resources/sql/importer/populate_lines_with_jore4_ids.sql
+++ b/src/test/resources/sql/importer/populate_lines_with_jore4_ids.sql
@@ -11,8 +11,8 @@ VALUES (
         '579db108-1f52-4364-9815-5f17c84ce3fb',
         '1001',
         '1',
-        'tram_track',
+        'road',
         '5aa7d9fc-2cf9-466d-8ac0-f442d60c261f',
-        'city_tram_service',
+        'stopping_bus_service',
         'HELSINKI'
 );


### PR DESCRIPTION
Since a few years ago the last three digits of the line/route number were not unique, and since in Jore4 the line/route number uses only those last three digits (stripping the preceding digit for the legacy municipality code), the lines of the `LEGACY_NOT_USED` municipality code are filtered out to avoid uniqueness constraint problems in the Jore4 database.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/135)
<!-- Reviewable:end -->
