### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
   push_to_registry:
     needs: run_java_tests
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check-renovatebot-config.yml
+++ b/.github/workflows/check-renovatebot-config.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
         with:
           config_file_path: .github/renovate.json5

--- a/.github/workflows/generate-jooq.yml
+++ b/.github/workflows/generate-jooq.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   generate-jooq:
     name: Verifies whether generated jooq classes have been updated
+    # These must run on ubuntu 22.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
     runs-on: ubuntu-22.04
 
     steps:
@@ -26,13 +29,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Run jooq class generation
         run: ./development.sh generate:jooq --no-volume

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   run-tests:
     name: Run java tests
+    # These must run on ubuntu 22.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
     runs-on: ubuntu-22.04
 
     steps:
@@ -25,13 +28,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Verify whether test mssql db is up
         uses: HSLdevcom/jore4-tools/github-actions/healthcheck@healthcheck-v1

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   spotless:
     name: Check code is formatted with Spotless
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -19,13 +19,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Run Spotless Check
         run: mvn spotless:check


### PR DESCRIPTION
* Run on Ubuntu 24.04 or 22.04 for tasks requiring e2e env
* Use actions/setup-java build-in cache
* Update suzuki-shunsuke/github-action-renovate-config-validator to  1.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/144)
<!-- Reviewable:end -->
