### PR TITLE
Github: Update E2E related workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,10 @@ jobs:
       - run_java_tests
       - push_to_registry
     name: Run E2E tests
-    runs-on: ubuntu-22.04
+    # These must run on ubuntu 20.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
+    runs-on: ubuntu-20.04
     steps:
       - name: Extract metadata to env variables
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
@@ -82,3 +85,4 @@ jobs:
         uses: HSLdevcom/jore4-tools/github-actions/run-ci@main
         with:
           jore3importer_version: "${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }}"
+          start_jore3_importer: "true"

--- a/.github/workflows/generate-jooq.yml
+++ b/.github/workflows/generate-jooq.yml
@@ -8,19 +8,20 @@ on:
 jobs:
   generate-jooq:
     name: Verifies whether generated jooq classes have been updated
-    # These must run on ubuntu 22.04 or older.
+    # These must run on ubuntu 20.04 or older.
     # The MS SQL server used by jore4-jore3-importer,
     # does not run on Linux kernels newer than 6.6.x.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Start e2e env
-        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v6
+        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v7
         with:
           custom_docker_compose: ./docker/docker-compose.custom.yml
+          start_jore3_importer: "true"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -7,19 +7,20 @@ on:
 jobs:
   run-tests:
     name: Run java tests
-    # These must run on ubuntu 22.04 or older.
+    # These must run on ubuntu 20.04 or older.
     # The MS SQL server used by jore4-jore3-importer,
     # does not run on Linux kernels newer than 6.6.x.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Start e2e env
-        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v6
+        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v7
         with:
           custom_docker_compose: ./docker/docker-compose.custom.yml
+          start_jore3_importer: "true"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
* Use start task version 7
* Instruct the task to start the importer services
* Downgrade Ubuntu to 20.04, as 22.04 is no longer viable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/145)
<!-- Reviewable:end -->
