### PR TITLE
Update Spring Boot from `3.3.0` to `3.4.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>fi.hsl.jore</groupId>

--- a/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/infrastructure_network/tables/InfrastructureLinks.java
+++ b/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/infrastructure_network/tables/InfrastructureLinks.java
@@ -185,20 +185,21 @@ public class InfrastructureLinks extends TableImpl<InfrastructureLinksRecord> {
 
     @Override
     public List<ForeignKey<InfrastructureLinksRecord, ?>> getReferences() {
-        return Arrays.asList(Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_NETWORK_TYPE_FKEY, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_START_NODE_FKEY, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_END_NODE_FKEY);
+        return Arrays.asList(Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_END_NODE_FKEY, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_START_NODE_FKEY, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_NETWORK_TYPE_FKEY);
     }
 
-    private transient InfrastructureNetworkTypesPath _infrastructureNetworkTypes;
+    private transient InfrastructureNodesPath _infrastructureLinksInfrastructureLinkEndNodeFkey;
 
     /**
      * Get the implicit join path to the
-     * <code>infrastructure_network.infrastructure_network_types</code> table.
+     * <code>infrastructure_network.infrastructure_nodes</code> table, via the
+     * <code>infrastructure_links_infrastructure_link_end_node_fkey</code> key.
      */
-    public InfrastructureNetworkTypesPath infrastructureNetworkTypes() {
-        if (_infrastructureNetworkTypes == null)
-            _infrastructureNetworkTypes = new InfrastructureNetworkTypesPath(this, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_NETWORK_TYPE_FKEY, null);
+    public InfrastructureNodesPath infrastructureLinksInfrastructureLinkEndNodeFkey() {
+        if (_infrastructureLinksInfrastructureLinkEndNodeFkey == null)
+            _infrastructureLinksInfrastructureLinkEndNodeFkey = new InfrastructureNodesPath(this, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_END_NODE_FKEY, null);
 
-        return _infrastructureNetworkTypes;
+        return _infrastructureLinksInfrastructureLinkEndNodeFkey;
     }
 
     private transient InfrastructureNodesPath _infrastructureLinksInfrastructureLinkStartNodeFkey;
@@ -216,18 +217,17 @@ public class InfrastructureLinks extends TableImpl<InfrastructureLinksRecord> {
         return _infrastructureLinksInfrastructureLinkStartNodeFkey;
     }
 
-    private transient InfrastructureNodesPath _infrastructureLinksInfrastructureLinkEndNodeFkey;
+    private transient InfrastructureNetworkTypesPath _infrastructureNetworkTypes;
 
     /**
      * Get the implicit join path to the
-     * <code>infrastructure_network.infrastructure_nodes</code> table, via the
-     * <code>infrastructure_links_infrastructure_link_end_node_fkey</code> key.
+     * <code>infrastructure_network.infrastructure_network_types</code> table.
      */
-    public InfrastructureNodesPath infrastructureLinksInfrastructureLinkEndNodeFkey() {
-        if (_infrastructureLinksInfrastructureLinkEndNodeFkey == null)
-            _infrastructureLinksInfrastructureLinkEndNodeFkey = new InfrastructureNodesPath(this, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_LINK_END_NODE_FKEY, null);
+    public InfrastructureNetworkTypesPath infrastructureNetworkTypes() {
+        if (_infrastructureNetworkTypes == null)
+            _infrastructureNetworkTypes = new InfrastructureNetworkTypesPath(this, Keys.INFRASTRUCTURE_LINKS__INFRASTRUCTURE_LINKS_INFRASTRUCTURE_NETWORK_TYPE_FKEY, null);
 
-        return _infrastructureLinksInfrastructureLinkEndNodeFkey;
+        return _infrastructureNetworkTypes;
     }
 
     private transient InfrastructureLinkShapesPath _infrastructureLinkShapes;

--- a/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRouteDirections.java
+++ b/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRouteDirections.java
@@ -220,20 +220,7 @@ public class NetworkRouteDirections extends TableImpl<NetworkRouteDirectionsReco
 
     @Override
     public List<ForeignKey<NetworkRouteDirectionsRecord, ?>> getReferences() {
-        return Arrays.asList(Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_ID_FKEY, Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_DIRECTION_TYPE_FKEY);
-    }
-
-    private transient NetworkRoutesPath _networkRoutes;
-
-    /**
-     * Get the implicit join path to the <code>network.network_routes</code>
-     * table.
-     */
-    public NetworkRoutesPath networkRoutes() {
-        if (_networkRoutes == null)
-            _networkRoutes = new NetworkRoutesPath(this, Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_ID_FKEY, null);
-
-        return _networkRoutes;
+        return Arrays.asList(Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_DIRECTION_TYPE_FKEY, Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_ID_FKEY);
     }
 
     private transient NetworkDirectionTypesPath _networkDirectionTypes;
@@ -247,6 +234,19 @@ public class NetworkRouteDirections extends TableImpl<NetworkRouteDirectionsReco
             _networkDirectionTypes = new NetworkDirectionTypesPath(this, Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_DIRECTION_TYPE_FKEY, null);
 
         return _networkDirectionTypes;
+    }
+
+    private transient NetworkRoutesPath _networkRoutes;
+
+    /**
+     * Get the implicit join path to the <code>network.network_routes</code>
+     * table.
+     */
+    public NetworkRoutesPath networkRoutes() {
+        if (_networkRoutes == null)
+            _networkRoutes = new NetworkRoutesPath(this, Keys.NETWORK_ROUTE_DIRECTIONS__NETWORK_ROUTE_DIRECTIONS_NETWORK_ROUTE_ID_FKEY, null);
+
+        return _networkRoutes;
     }
 
     private transient NetworkRouteLinksPath _networkRouteLinks;

--- a/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRouteLinks.java
+++ b/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRouteLinks.java
@@ -173,20 +173,7 @@ public class NetworkRouteLinks extends TableImpl<NetworkRouteLinksRecord> {
 
     @Override
     public List<ForeignKey<NetworkRouteLinksRecord, ?>> getReferences() {
-        return Arrays.asList(Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_NETWORK_ROUTE_DIRECTION_ID_FKEY, Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_INFRASTRUCTURE_LINK_ID_FKEY);
-    }
-
-    private transient NetworkRouteDirectionsPath _networkRouteDirections;
-
-    /**
-     * Get the implicit join path to the
-     * <code>network.network_route_directions</code> table.
-     */
-    public NetworkRouteDirectionsPath networkRouteDirections() {
-        if (_networkRouteDirections == null)
-            _networkRouteDirections = new NetworkRouteDirectionsPath(this, Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_NETWORK_ROUTE_DIRECTION_ID_FKEY, null);
-
-        return _networkRouteDirections;
+        return Arrays.asList(Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_INFRASTRUCTURE_LINK_ID_FKEY, Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_NETWORK_ROUTE_DIRECTION_ID_FKEY);
     }
 
     private transient InfrastructureLinksPath _infrastructureLinks;
@@ -200,6 +187,19 @@ public class NetworkRouteLinks extends TableImpl<NetworkRouteLinksRecord> {
             _infrastructureLinks = new InfrastructureLinksPath(this, Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_INFRASTRUCTURE_LINK_ID_FKEY, null);
 
         return _infrastructureLinks;
+    }
+
+    private transient NetworkRouteDirectionsPath _networkRouteDirections;
+
+    /**
+     * Get the implicit join path to the
+     * <code>network.network_route_directions</code> table.
+     */
+    public NetworkRouteDirectionsPath networkRouteDirections() {
+        if (_networkRouteDirections == null)
+            _networkRouteDirections = new NetworkRouteDirectionsPath(this, Keys.NETWORK_ROUTE_LINKS__NETWORK_ROUTE_LINKS_NETWORK_ROUTE_DIRECTION_ID_FKEY, null);
+
+        return _networkRouteDirections;
     }
 
     @Override

--- a/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRoutePoints.java
+++ b/src/main/generated-sources/jooq/fi/hsl/jore/importer/jooq/network/tables/NetworkRoutePoints.java
@@ -173,20 +173,7 @@ public class NetworkRoutePoints extends TableImpl<NetworkRoutePointsRecord> {
 
     @Override
     public List<ForeignKey<NetworkRoutePointsRecord, ?>> getReferences() {
-        return Arrays.asList(Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_NETWORK_ROUTE_DIRECTION_ID_FKEY, Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_INFRASTRUCTURE_NODE_FKEY);
-    }
-
-    private transient NetworkRouteDirectionsPath _networkRouteDirections;
-
-    /**
-     * Get the implicit join path to the
-     * <code>network.network_route_directions</code> table.
-     */
-    public NetworkRouteDirectionsPath networkRouteDirections() {
-        if (_networkRouteDirections == null)
-            _networkRouteDirections = new NetworkRouteDirectionsPath(this, Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_NETWORK_ROUTE_DIRECTION_ID_FKEY, null);
-
-        return _networkRouteDirections;
+        return Arrays.asList(Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_INFRASTRUCTURE_NODE_FKEY, Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_NETWORK_ROUTE_DIRECTION_ID_FKEY);
     }
 
     private transient InfrastructureNodesPath _infrastructureNodes;
@@ -200,6 +187,19 @@ public class NetworkRoutePoints extends TableImpl<NetworkRoutePointsRecord> {
             _infrastructureNodes = new InfrastructureNodesPath(this, Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_INFRASTRUCTURE_NODE_FKEY, null);
 
         return _infrastructureNodes;
+    }
+
+    private transient NetworkRouteDirectionsPath _networkRouteDirections;
+
+    /**
+     * Get the implicit join path to the
+     * <code>network.network_route_directions</code> table.
+     */
+    public NetworkRouteDirectionsPath networkRouteDirections() {
+        if (_networkRouteDirections == null)
+            _networkRouteDirections = new NetworkRouteDirectionsPath(this, Keys.NETWORK_ROUTE_POINTS__NETWORK_ROUTE_POINTS_NETWORK_ROUTE_DIRECTION_ID_FKEY, null);
+
+        return _networkRouteDirections;
     }
 
     private transient NetworkRouteStopPointsPath _networkRouteStopPoints;

--- a/src/main/java/fi/hsl/jore/importer/config/jobs/BatchConfig.java
+++ b/src/main/java/fi/hsl/jore/importer/config/jobs/BatchConfig.java
@@ -2,7 +2,6 @@ package fi.hsl.jore.importer.config.jobs;
 
 import javax.sql.DataSource;
 import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.boot.autoconfigure.batch.BatchTransactionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -44,10 +43,5 @@ public class BatchConfig extends DefaultBatchConfiguration {
     @BatchTransactionManager
     public PlatformTransactionManager batchTransactionManager() {
         return getTransactionManager();
-    }
-
-    @Bean
-    public static BeanDefinitionRegistryPostProcessor jobRegistryBeanPostProcessorRemover() {
-        return registry -> registry.removeBeanDefinition("jobRegistryBeanPostProcessor");
     }
 }


### PR DESCRIPTION
Remove the bean `jobRegistryBeanPostProcessorRemover` because it fails the build. There doesn't seem to be any documentation as to why that bean was added in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-jore3-importer/150)
<!-- Reviewable:end -->
